### PR TITLE
feat: add latency flag

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -114,6 +114,7 @@ func GetAPI(id string) (model.GetMeasurement, error) {
 	var data model.GetMeasurement
 	err = json.NewDecoder(resp.Body).Decode(&data)
 	if err != nil {
+		fmt.Println(err)
 		return model.GetMeasurement{}, errors.New("invalid get measurement format returned")
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -83,6 +83,24 @@ func PostAPI(measurement model.PostMeasurement) (model.PostResponse, error) {
 	return data, nil
 }
 
+func DecodeTimings(cmd string, timings json.RawMessage) (model.Timings, error) {
+	var data model.Timings
+
+	if cmd == "ping" {
+		err := json.Unmarshal(timings, &data.Arr)
+		if err != nil {
+			return model.Timings{}, errors.New("invalid timings format returned (ping)")
+		}
+	} else {
+		err := json.Unmarshal(timings, &data.Interface)
+		if err != nil {
+			return model.Timings{}, errors.New("invalid timings format returned (other)")
+		}
+	}
+
+	return data, nil
+}
+
 // Get measurement from Globalping API
 func GetAPI(id string) (model.GetMeasurement, error) {
 	// Create a new request
@@ -112,8 +130,7 @@ func GetAPI(id string) (model.GetMeasurement, error) {
 
 	// Read the response body
 	var data model.GetMeasurement
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		fmt.Println(err)
 		return model.GetMeasurement{}, errors.New("invalid get measurement format returned")
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -107,6 +107,8 @@ func testPostInternalError(t *testing.T) {
 func TestGetAPI(t *testing.T) {
 	for scenario, fn := range map[string]func(t *testing.T){
 		"valid": testGetValid,
+		"json":  testGetJson,
+		"ping":  testGetPing,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			fn(t)
@@ -114,7 +116,6 @@ func TestGetAPI(t *testing.T) {
 	}
 }
 
-// Test a valid call of GetAPI
 func testGetValid(t *testing.T) {
 	server := generateServer(`{"id":"abcd"}`)
 	defer server.Close()
@@ -126,4 +127,74 @@ func testGetValid(t *testing.T) {
 	}
 
 	assert.Equal(t, "abcd", res.ID)
+}
+
+func testGetJson(t *testing.T) {
+	server := generateServer(`{"id":"abcd"}`)
+	defer server.Close()
+	client.ApiUrl = server.URL
+
+	res, err := client.GetApiJson("abcd")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, `{"id":"abcd"}`, res)
+}
+
+func testGetPing(t *testing.T) {
+	server := generateServer(`{
+    "id": "abcd",
+    "type": "ping",
+    "status": "finished",
+    "createdAt": "2022-07-17T16:19:52.909Z",
+    "updatedAt": "2022-07-17T16:19:52.909Z",
+    "results": [
+        {
+            "probe": {
+                "continent": "AF",
+                "country": "ZA",
+                "state": null,
+                "city": "cape town",
+                "asn": 16509,
+                "network": "amazon.com inc.",
+                "tags": []
+            },
+            "result": {
+                "timings": [
+                    {
+                        "ttl": 108,
+                        "rtt": 16.5
+                    },
+                    {
+                        "ttl": 108,
+                        "rtt": 16.5
+                    },
+                    {
+                        "ttl": 108,
+                        "rtt": 16.5
+                    }
+                ],
+                "stats": {
+                  "min": 16.474,
+                  "avg": 16.504,
+                  "max": 16.543,
+                  "loss": 0,
+                },
+                "rawOutput": "PING"
+            }
+        }
+	]}`)
+	defer server.Close()
+	client.ApiUrl = server.URL
+
+	res, err := client.GetAPI("abcd")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "abcd", res.ID)
+	assert.Equal(t, "ping", res.Type)
+	assert.Equal(t, "finished", res.Status)
+
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -111,9 +112,13 @@ func testPostInternalError(t *testing.T) {
 // GetAPI tests
 func TestGetAPI(t *testing.T) {
 	for scenario, fn := range map[string]func(t *testing.T){
-		"valid": testGetValid,
-		"json":  testGetJson,
-		"ping":  testGetPing,
+		"valid":      testGetValid,
+		"json":       testGetJson,
+		"ping":       testGetPing,
+		"traceroute": testGetTraceroute,
+		"dns":        testGetDns,
+		"mtr":        testGetMtr,
+		"http":       testGetHttp,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			fn(t)
@@ -226,4 +231,405 @@ func testGetPing(t *testing.T) {
 	assert.Equal(t, float64(3), res.Results[0].Result.Stats["rcv"])
 	assert.Equal(t, float64(0), res.Results[0].Result.Stats["loss"])
 	assert.Equal(t, float64(0), res.Results[0].Result.Stats["drop"])
+}
+
+func testGetTraceroute(t *testing.T) {
+	server := generateServer(`{
+	"id": "abcd",
+	"type": "traceroute",
+	"status": "finished",
+	"createdAt": "2023-02-23T07:55:23.414Z",
+	"updatedAt": "2023-02-23T07:55:25.496Z",
+	"probesCount": 1,
+	"results": [
+		{
+		"probe": {
+			"continent": "EU",
+			"region": "Northern Europe",
+			"country": "GB",
+			"state": null,
+			"city": "London",
+			"asn": 16276,
+			"longitude": -0.1257,
+			"latitude": 51.5085,
+			"network": "OVH SAS",
+			"tags": [],
+			"resolvers": [
+			"private"
+			]
+		},
+		"result": {
+			"rawOutput": "TRACEROUTE",
+			"status": "finished",
+			"resolvedAddress": "1.1.1.1",
+			"resolvedHostname": "1.1.1.1",
+			"hops": [
+			{
+				"resolvedHostname": "54.37.244.252",
+				"resolvedAddress": "54.37.244.252",
+				"timings": [
+				{
+					"rtt": 0.408
+				},
+				{
+					"rtt": 0.502
+				}
+				]
+			},
+			{
+				"resolvedHostname": "93.123.11.62",
+				"resolvedAddress": "93.123.11.62",
+				"timings": [
+				{
+					"rtt": 0.507
+				},
+				{
+					"rtt": 0.524
+				}
+				]
+			}
+			]
+	}}]}`)
+	defer server.Close()
+	client.ApiUrl = server.URL
+
+	res, err := client.GetAPI("abcd")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "abcd", res.ID)
+	assert.Equal(t, "traceroute", res.Type)
+	assert.Equal(t, "finished", res.Status)
+	assert.Equal(t, "2023-02-23T07:55:23.414Z", res.CreatedAt)
+	assert.Equal(t, "2023-02-23T07:55:25.496Z", res.UpdatedAt)
+	assert.Equal(t, 1, res.ProbesCount)
+	assert.Equal(t, 1, len(res.Results))
+
+	assert.Equal(t, "EU", res.Results[0].Probe.Continent)
+	assert.Equal(t, "Northern Europe", res.Results[0].Probe.Region)
+	assert.Equal(t, "GB", res.Results[0].Probe.Country)
+	assert.Equal(t, "", res.Results[0].Probe.State)
+	assert.Equal(t, "London", res.Results[0].Probe.City)
+	assert.Equal(t, 16276, res.Results[0].Probe.ASN)
+	assert.Equal(t, "OVH SAS", res.Results[0].Probe.Network)
+	assert.Equal(t, 0, len(res.Results[0].Probe.Tags))
+
+	assert.Equal(t, "TRACEROUTE", res.Results[0].Result.RawOutput)
+	assert.Equal(t, "1.1.1.1", res.Results[0].Result.ResolvedAddress)
+	assert.Equal(t, "1.1.1.1", res.Results[0].Result.ResolvedHostname)
+}
+
+func testGetDns(t *testing.T) {
+	server := generateServer(`{
+	"id": "abcd",
+	"type": "dns",
+	"status": "finished",
+	"createdAt": "2023-02-23T08:00:37.431Z",
+	"updatedAt": "2023-02-23T08:00:37.640Z",
+	"probesCount": 1,
+	"results": [
+		{
+		"probe": {
+			"continent": "EU",
+			"region": "Western Europe",
+			"country": "NL",
+			"state": null,
+			"city": "Amsterdam",
+			"asn": 60404,
+			"longitude": 4.8897,
+			"latitude": 52.374,
+			"network": "Liteserver",
+			"tags": [],
+			"resolvers": [
+			"185.31.172.240",
+			"89.188.29.4"
+			]
+		},
+		"result": {
+			"status": "finished",
+			"statusCodeName": "NOERROR",
+			"statusCode": 0,
+			"rawOutput": "DNS",
+			"answers": [
+			{
+				"name": "jsdelivr.com.",
+				"type": "A",
+				"ttl": 30,
+				"class": "IN",
+				"value": "92.223.84.84"
+			}
+			],
+			"timings": {
+			"total": 15
+			},
+			"resolver": "185.31.172.240"
+		}
+	}]}`)
+	defer server.Close()
+	client.ApiUrl = server.URL
+
+	res, err := client.GetAPI("abcd")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "abcd", res.ID)
+	assert.Equal(t, "dns", res.Type)
+	assert.Equal(t, "finished", res.Status)
+	assert.Equal(t, "2023-02-23T08:00:37.431Z", res.CreatedAt)
+	assert.Equal(t, "2023-02-23T08:00:37.640Z", res.UpdatedAt)
+	assert.Equal(t, 1, res.ProbesCount)
+	assert.Equal(t, 1, len(res.Results))
+
+	assert.Equal(t, "EU", res.Results[0].Probe.Continent)
+	assert.Equal(t, "Western Europe", res.Results[0].Probe.Region)
+	assert.Equal(t, "NL", res.Results[0].Probe.Country)
+	assert.Equal(t, "", res.Results[0].Probe.State)
+	assert.Equal(t, "Amsterdam", res.Results[0].Probe.City)
+	assert.Equal(t, 60404, res.Results[0].Probe.ASN)
+	assert.Equal(t, "Liteserver", res.Results[0].Probe.Network)
+	assert.Equal(t, 0, len(res.Results[0].Probe.Tags))
+
+	assert.Equal(t, "DNS", res.Results[0].Result.RawOutput)
+	assert.Equal(t, "finished", res.Results[0].Result.Status)
+	assert.IsType(t, json.RawMessage{}, res.Results[0].Result.TimingsRaw)
+
+	// Test timings
+	timings, _ := client.DecodeTimings("dns", res.Results[0].Result.TimingsRaw)
+	assert.Equal(t, float64(15), timings.Interface["total"])
+	assert.Nil(t, timings.Arr)
+}
+
+func testGetMtr(t *testing.T) {
+	server := generateServer(`{
+	"id": "abcd",
+	"type": "mtr",
+	"status": "finished",
+	"createdAt": "2023-02-23T08:08:25.187Z",
+	"updatedAt": "2023-02-23T08:08:29.829Z",
+	"probesCount": 1,
+	"results": [
+		{
+		"probe": {
+			"continent": "EU",
+			"region": "Western Europe",
+			"country": "NL",
+			"state": null,
+			"city": "Amsterdam",
+			"asn": 54825,
+			"longitude": 4.8897,
+			"latitude": 52.374,
+			"network": "Packet Host, Inc.",
+			"tags": [],
+			"resolvers": []
+		},
+		"result": {
+			"status": "finished",
+			"rawOutput": "MTR",
+			"resolvedAddress": "92.223.84.84",
+			"resolvedHostname": "92.223.84.84",
+			"hops": [
+			{
+				"stats": {
+				"min": 0.176,
+				"max": 0.226,
+				"avg": 0.2,
+				"total": 3,
+				"loss": 0,
+				"rcv": 3,
+				"drop": 0,
+				"stDev": 0,
+				"jMin": 0,
+				"jMax": 0.2,
+				"jAvg": 0.1
+				},
+				"asn": [],
+				"timings": [
+				{
+					"rtt": 0.176
+				},
+				{
+					"rtt": 0.216
+				},
+				{
+					"rtt": 0.226
+				}
+				],
+				"resolvedAddress": "172.19.66.225",
+				"duplicate": false,
+				"resolvedHostname": "172.19.66.225"
+			},
+			{
+				"stats": {
+				"min": 0.894,
+				"max": 0.894,
+				"avg": 0.9,
+				"total": 1,
+				"loss": 0,
+				"rcv": 1,
+				"drop": 0,
+				"stDev": 0,
+				"jMin": 0.9,
+				"jMax": 0.9,
+				"jAvg": 0.9
+				},
+				"asn": [
+				199524
+				],
+				"timings": [
+				{
+					"rtt": 0.894
+				}
+				],
+				"resolvedAddress": "92.223.84.84",
+				"duplicate": true,
+				"resolvedHostname": "92.223.84.84"
+			}
+			]
+		}
+	}]}`)
+	defer server.Close()
+	client.ApiUrl = server.URL
+
+	res, err := client.GetAPI("abcd")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "abcd", res.ID)
+	assert.Equal(t, "mtr", res.Type)
+	assert.Equal(t, "finished", res.Status)
+	assert.Equal(t, "2023-02-23T08:08:25.187Z", res.CreatedAt)
+	assert.Equal(t, "2023-02-23T08:08:29.829Z", res.UpdatedAt)
+	assert.Equal(t, 1, res.ProbesCount)
+	assert.Equal(t, 1, len(res.Results))
+
+	assert.Equal(t, "EU", res.Results[0].Probe.Continent)
+	assert.Equal(t, "Western Europe", res.Results[0].Probe.Region)
+	assert.Equal(t, "NL", res.Results[0].Probe.Country)
+	assert.Equal(t, "", res.Results[0].Probe.State)
+	assert.Equal(t, "Amsterdam", res.Results[0].Probe.City)
+	assert.Equal(t, 54825, res.Results[0].Probe.ASN)
+	assert.Equal(t, "Packet Host, Inc.", res.Results[0].Probe.Network)
+	assert.Equal(t, 0, len(res.Results[0].Probe.Tags))
+
+	assert.Equal(t, "MTR", res.Results[0].Result.RawOutput)
+	assert.Equal(t, "finished", res.Results[0].Result.Status)
+	assert.IsType(t, json.RawMessage{}, res.Results[0].Result.TimingsRaw)
+}
+
+func testGetHttp(t *testing.T) {
+	server := generateServer(`{
+	"id": "abcd",
+	"type": "http",
+	"status": "finished",
+	"createdAt": "2023-02-23T08:16:11.335Z",
+	"updatedAt": "2023-02-23T08:16:12.548Z",
+	"probesCount": 1,
+	"results": [
+		{
+		"probe": {
+			"continent": "NA",
+			"region": "Northern America",
+			"country": "CA",
+			"state": null,
+			"city": "Pembroke",
+			"asn": 577,
+			"longitude": -77.1162,
+			"latitude": 45.8168,
+			"network": "Bell Canada",
+			"tags": [],
+			"resolvers": [
+			"private",
+			"private"
+			]
+		},
+		"result": {
+			"status": "finished",
+			"resolvedAddress": "5.101.222.14",
+			"headers": {
+			"server": "nginx",
+			"date": "Thu, 23 Feb 2023 08:16:12 GMT",
+			"content-type": "text/html; charset=utf-8",
+			"connection": "close",
+			"location": "/",
+			"cf-ray": "79de849d3fa30c33-AMS",
+			"vary": "Accept-Encoding",
+			"cf-cache-status": "DYNAMIC",
+			"x-render-origin-server": "Render",
+			"x-response-time": "1ms",
+			"cache": "MISS, MISS",
+			"x-id": "am3-up-gc88, td2-up-gc10",
+			"x-nginx": "nginx-be, nginx-be"
+			},
+			"rawHeaders": "Server: nginx\nDate: Thu, 23 Feb 2023 08:16:12 GMT\nContent-Type: text/html; charset=utf-8\nConnection: close\nLocation: /\nCF-Ray: 79de849d3fa30c33-AMS\nVary: Accept-Encoding\nCF-Cache-Status: DYNAMIC\nx-render-origin-server: Render\nx-response-time: 1ms\nCache: MISS\nX-ID: am3-up-gc88\nX-NGINX: nginx-be\nCache: MISS\nX-ID: td2-up-gc10\nX-NGINX: nginx-be",
+			"rawBody": null,
+			"statusCode": 301,
+			"statusCodeName": "Moved Permanently",
+			"timings": {
+			"total": 583,
+			"download": 18,
+			"firstByte": 450,
+			"dns": 24,
+			"tls": 70,
+			"tcp": 19
+			},
+			"tls": {
+			"authorized": true,
+			"createdAt": "2023-02-18T00:00:00.000Z",
+			"expiresAt": "2024-02-18T23:59:59.000Z",
+			"issuer": {
+				"C": "GB",
+				"ST": "Greater Manchester",
+				"L": "Salford",
+				"O": "Sectigo Limited",
+				"CN": "Sectigo RSA Domain Validation Secure Server CA"
+			},
+			"subject": {
+				"CN": "jsdelivr.com",
+				"alt": "DNS:jsdelivr.com, DNS:data.jsdelivr.com, DNS:www.jsdelivr.com"
+			}
+			},
+			"rawOutput": "HTTP"
+		}
+	}]}`)
+	defer server.Close()
+	client.ApiUrl = server.URL
+
+	res, err := client.GetAPI("abcd")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "abcd", res.ID)
+	assert.Equal(t, "http", res.Type)
+	assert.Equal(t, "finished", res.Status)
+	assert.Equal(t, "2023-02-23T08:16:11.335Z", res.CreatedAt)
+	assert.Equal(t, "2023-02-23T08:16:12.548Z", res.UpdatedAt)
+	assert.Equal(t, 1, res.ProbesCount)
+	assert.Equal(t, 1, len(res.Results))
+
+	assert.Equal(t, "NA", res.Results[0].Probe.Continent)
+	assert.Equal(t, "Northern America", res.Results[0].Probe.Region)
+	assert.Equal(t, "CA", res.Results[0].Probe.Country)
+	assert.Equal(t, "", res.Results[0].Probe.State)
+	assert.Equal(t, "Pembroke", res.Results[0].Probe.City)
+	assert.Equal(t, 577, res.Results[0].Probe.ASN)
+	assert.Equal(t, "Bell Canada", res.Results[0].Probe.Network)
+	assert.Equal(t, 0, len(res.Results[0].Probe.Tags))
+
+	assert.Equal(t, "HTTP", res.Results[0].Result.RawOutput)
+	assert.Equal(t, "finished", res.Results[0].Result.Status)
+	assert.IsType(t, json.RawMessage{}, res.Results[0].Result.TimingsRaw)
+
+	// Test timings
+	timings, _ := client.DecodeTimings("dns", res.Results[0].Result.TimingsRaw)
+	assert.Nil(t, timings.Arr)
+	assert.Equal(t, float64(583), timings.Interface["total"])
+	assert.Equal(t, float64(18), timings.Interface["download"])
+	assert.Equal(t, float64(450), timings.Interface["firstByte"])
+	assert.Equal(t, float64(24), timings.Interface["dns"])
+	assert.Equal(t, float64(70), timings.Interface["tls"])
+	assert.Equal(t, float64(19), timings.Interface["tcp"])
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/jsdelivr/globalping-cli/client"
@@ -33,6 +34,8 @@ var opts = model.PostMeasurement{}
 
 // PostAPI tests
 func TestPostAPI(t *testing.T) {
+	// Suppress error outputs
+	os.Stdout, _ = os.Open(os.DevNull)
 	for scenario, fn := range map[string]func(t *testing.T){
 		"valid":      testPostValid,
 		"no_probes":  testPostNoProbes,
@@ -126,6 +129,8 @@ func testGetValid(t *testing.T) {
 		t.Error(err)
 	}
 
+	t.Logf("%+v", res)
+
 	assert.Equal(t, "abcd", res.ID)
 }
 
@@ -144,47 +149,47 @@ func testGetJson(t *testing.T) {
 
 func testGetPing(t *testing.T) {
 	server := generateServer(`{
-    "id": "abcd",
-    "type": "ping",
-    "status": "finished",
-    "createdAt": "2022-07-17T16:19:52.909Z",
-    "updatedAt": "2022-07-17T16:19:52.909Z",
-    "results": [
-        {
-            "probe": {
-                "continent": "AF",
-                "country": "ZA",
-                "state": null,
-                "city": "cape town",
-                "asn": 16509,
-                "network": "amazon.com inc.",
-                "tags": []
-            },
-            "result": {
-                "timings": [
-                    {
-                        "ttl": 108,
-                        "rtt": 16.5
-                    },
-                    {
-                        "ttl": 108,
-                        "rtt": 16.5
-                    },
-                    {
-                        "ttl": 108,
-                        "rtt": 16.5
-                    }
-                ],
-                "stats": {
-                  "min": 16.474,
-                  "avg": 16.504,
-                  "max": 16.543,
-                  "loss": 0,
-                },
-                "rawOutput": "PING"
-            }
-        }
-	]}`)
+	"id": "abcd",
+	"type": "ping",
+	"status": "finished",
+	"createdAt": "2023-02-17T18:11:52.825Z",
+	"updatedAt": "2023-02-17T18:11:53.969Z",
+	"probesCount": 1,
+	"results": [
+		{
+		"probe": {
+			"continent": "NA",
+			"region": "Northern America",
+			"country": "CA",
+			"state": null,
+			"city": "City",
+			"asn": 7794,
+			"longitude": -80.2222,
+			"latitude": 43.3662,
+			"network": "Network",
+			"tags": [],
+			"resolvers": [
+			"1.1.1.1",
+			"8.8.4.4"
+			]
+		},
+		"result": {
+			"status": "finished",
+			"rawOutput": "PING",
+			"resolvedAddress": "1.1.1.1",
+			"resolvedHostname": "1.1.1.1:",
+			"timings": [],
+			"stats": {
+				"min": 24.891,
+				"max": 28.193,
+				"avg": 27.088,
+				"total": 3,
+				"loss": 0,
+				"rcv": 3,
+				"drop": 0
+			}
+		}
+	}]}`)
 	defer server.Close()
 	client.ApiUrl = server.URL
 
@@ -196,5 +201,27 @@ func testGetPing(t *testing.T) {
 	assert.Equal(t, "abcd", res.ID)
 	assert.Equal(t, "ping", res.Type)
 	assert.Equal(t, "finished", res.Status)
+	assert.Equal(t, "2023-02-17T18:11:52.825Z", res.CreatedAt)
+	assert.Equal(t, "2023-02-17T18:11:53.969Z", res.UpdatedAt)
+	assert.Equal(t, 1, res.ProbesCount)
+	assert.Equal(t, 1, len(res.Results))
 
+	assert.Equal(t, "NA", res.Results[0].Probe.Continent)
+	assert.Equal(t, "Northern America", res.Results[0].Probe.Region)
+	assert.Equal(t, "CA", res.Results[0].Probe.Country)
+	assert.Equal(t, "", res.Results[0].Probe.State)
+	assert.Equal(t, "City", res.Results[0].Probe.City)
+	assert.Equal(t, 7794, res.Results[0].Probe.ASN)
+	assert.Equal(t, "Network", res.Results[0].Probe.Network)
+	assert.Equal(t, 0, len(res.Results[0].Probe.Tags))
+
+	assert.Equal(t, "PING", res.Results[0].Result.RawOutput)
+	assert.Equal(t, "1.1.1.1", res.Results[0].Result.ResolvedAddress)
+	assert.Equal(t, 27.088, res.Results[0].Result.Stats["avg"])
+	assert.Equal(t, 28.193, res.Results[0].Result.Stats["max"])
+	assert.Equal(t, 24.891, res.Results[0].Result.Stats["min"])
+	assert.Equal(t, float64(3), res.Results[0].Result.Stats["total"])
+	assert.Equal(t, float64(3), res.Results[0].Result.Stats["rcv"])
+	assert.Equal(t, float64(0), res.Results[0].Result.Stats["loss"])
+	assert.Equal(t, float64(0), res.Results[0].Result.Stats["drop"])
 }

--- a/client/view.go
+++ b/client/view.go
@@ -187,7 +187,7 @@ func OutputLatency(id string, ctx model.Context) {
 				fmt.Println(err)
 				return
 			}
-			output.WriteString(bold.Render("Total: ") + fmt.Sprintf("%v\n", timings.Interface["total"]))
+			output.WriteString(bold.Render("Total: ") + fmt.Sprintf("%v ms\n", timings.Interface["total"]))
 		}
 
 		if ctx.Cmd == "http" {
@@ -196,8 +196,12 @@ func OutputLatency(id string, ctx model.Context) {
 				fmt.Println(err)
 				return
 			}
-			output.WriteString(bold.Render("Total: ") + fmt.Sprintf("%v\n", timings.Interface["total"]))
-			output.WriteString(bold.Render("First byte: ") + fmt.Sprintf("%v\n", timings.Interface["firstByte"]))
+			output.WriteString(bold.Render("Total: ") + fmt.Sprintf("%v ms\n", timings.Interface["total"]))
+			output.WriteString(bold.Render("Download: ") + fmt.Sprintf("%v ms\n", timings.Interface["download"]))
+			output.WriteString(bold.Render("First byte: ") + fmt.Sprintf("%v ms\n", timings.Interface["firstByte"]))
+			output.WriteString(bold.Render("DNS: ") + fmt.Sprintf("%v ms\n", timings.Interface["dns"]))
+			output.WriteString(bold.Render("TLS: ") + fmt.Sprintf("%v ms\n", timings.Interface["tls"]))
+			output.WriteString(bold.Render("TCP: ") + fmt.Sprintf("%v ms\n", timings.Interface["tcp"]))
 		}
 	}
 

--- a/client/view.go
+++ b/client/view.go
@@ -175,11 +175,29 @@ func OutputLatency(id string, ctx model.Context) {
 		// Output slightly different format if state is available
 		output.WriteString(generateHeader(result) + "\n")
 
-		// Output only latency values if flag is set
-		if ctx.Cmd == "ping" || ctx.Cmd == "mtr" {
+		if ctx.Cmd == "ping" {
 			output.WriteString(bold.Render("Min: ") + fmt.Sprintf("%v ms\n", result.Result.Stats["min"]))
 			output.WriteString(bold.Render("Max: ") + fmt.Sprintf("%v ms\n", result.Result.Stats["max"]))
 			output.WriteString(bold.Render("Avg: ") + fmt.Sprintf("%v ms\n\n", result.Result.Stats["avg"]))
+		}
+
+		if ctx.Cmd == "dns" {
+			timings, err := DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			output.WriteString(bold.Render("Total: ") + fmt.Sprintf("%v\n", timings.Interface["total"]))
+		}
+
+		if ctx.Cmd == "http" {
+			timings, err := DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			output.WriteString(bold.Render("Total: ") + fmt.Sprintf("%v\n", timings.Interface["total"]))
+			output.WriteString(bold.Render("First byte: ") + fmt.Sprintf("%v\n", timings.Interface["firstByte"]))
 		}
 	}
 

--- a/client/view.go
+++ b/client/view.go
@@ -113,7 +113,7 @@ func LiveView(id string, ctx model.Context) {
 			if ctx.Latency {
 
 			} else {
-				output.WriteString("\n" + strings.TrimSpace(result.Result.RawOutput) + "\n\n")
+				output.WriteString("\n" + strings.TrimSpace(result.Result["rawOutput"].(string)) + "\n\n")
 			}
 
 		}

--- a/client/view.go
+++ b/client/view.go
@@ -119,7 +119,7 @@ func LiveView(id string, ctx model.Context) {
 	// Stop live updater and output to stdout
 	writer.RemoveWhenDone = true
 	writer.Stop()
-	fmt.Println(output.String())
+	fmt.Println(strings.TrimSpace(output.String()))
 }
 
 // If json flag is used, only output json
@@ -179,12 +179,7 @@ func OutputLatency(id string, ctx model.Context) {
 		if ctx.Cmd == "ping" || ctx.Cmd == "mtr" {
 			output.WriteString(bold.Render("Min: ") + fmt.Sprintf("%v ms\n", result.Result.Stats["min"]))
 			output.WriteString(bold.Render("Max: ") + fmt.Sprintf("%v ms\n", result.Result.Stats["max"]))
-			output.WriteString(bold.Render("Avg: ") + fmt.Sprintf("%v ms\n", result.Result.Stats["avg"]))
-
-			output.WriteString(bold.Render("Transmitted: ") + fmt.Sprintf("%v\n", result.Result.Stats["total"]))
-			output.WriteString(bold.Render("Received: ") + fmt.Sprintf("%v\n", result.Result.Stats["rcv"]))
-			output.WriteString(bold.Render("Dropped: ") + fmt.Sprintf("%v\n", result.Result.Stats["drop"]))
-			output.WriteString(bold.Render("Loss: ") + fmt.Sprintf("%v%%\n\n", result.Result.Stats["loss"]))
+			output.WriteString(bold.Render("Avg: ") + fmt.Sprintf("%v ms\n\n", result.Result.Stats["avg"]))
 		}
 	}
 

--- a/client/view.go
+++ b/client/view.go
@@ -113,7 +113,7 @@ func LiveView(id string, ctx model.Context) {
 			if ctx.Latency {
 
 			} else {
-				output.WriteString("\n" + strings.TrimSpace(result.Result["rawOutput"].(string)) + "\n\n")
+				output.WriteString("\n" + strings.TrimSpace(result.Result.RawOutput) + "\n\n")
 			}
 
 		}

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -20,7 +20,7 @@ var dnsCmd = &cobra.Command{
 	Args: checkCommandFormat(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create context
-		createContext(args)
+		createContext(cmd.CalledAs(), args)
 
 		// Make post struct
 		opts = model.PostMeasurement{

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -58,4 +58,7 @@ func init() {
 	dnsCmd.Flags().StringVar(&resolver, "resolver", "", "Resolver is the name or IP address of the name server to query (default empty)")
 	dnsCmd.Flags().StringVar(&queryType, "type", "", "Specifies the type of DNS query to perform (default \"A\")")
 	dnsCmd.Flags().BoolVar(&trace, "trace", false, "Toggle tracing of the delegation path from the root name servers (default false)")
+
+	// Extra flags
+	dnsCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -20,7 +20,7 @@ var httpCmd = &cobra.Command{
 	Args: checkCommandFormat(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create context
-		createContext(args)
+		createContext(cmd.CalledAs(), args)
 
 		// Make post struct
 		opts = model.PostMeasurement{

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -65,4 +65,6 @@ func init() {
 	httpCmd.Flags().IntVar(&port, "port", 0, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
 	httpCmd.Flags().StringVar(&resolver, "resolver", "", "Specifies the resolver server used for DNS lookup")
 
+	// Extra flags
+	httpCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
 }

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -52,4 +52,7 @@ func init() {
 	mtrCmd.Flags().StringVar(&protocol, "protocol", "", "Specifies the protocol used for tracerouting (ICMP, TCP or UDP) (default \"icmp\")")
 	mtrCmd.Flags().IntVar(&port, "port", 0, "Specifies the port to use for the traceroute. Only applicable for TCP protocol (default 53)")
 	mtrCmd.Flags().IntVar(&packets, "packets", 0, "Specifies the number of packets to send to each hop (default 3)")
+
+	// Extra flags
+	mtrCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
 }

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -20,7 +20,7 @@ var mtrCmd = &cobra.Command{
 	Args: checkCommandFormat(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create context
-		createContext(args)
+		createContext(cmd.CalledAs(), args)
 
 		// Make post struct
 		opts = model.PostMeasurement{

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -54,5 +54,5 @@ func init() {
 	mtrCmd.Flags().IntVar(&packets, "packets", 0, "Specifies the number of packets to send to each hop (default 3)")
 
 	// Extra flags
-	mtrCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
+	// mtrCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -48,4 +48,7 @@ func init() {
 
 	// ping specific flags
 	pingCmd.Flags().IntVar(&packets, "packets", 0, "Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)")
+
+	// Extra flags
+	pingCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -20,7 +20,7 @@ var pingCmd = &cobra.Command{
 	Args: checkCommandFormat(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create context
-		createContext(args)
+		createContext(cmd.CalledAs(), args)
 
 		// Make post struct
 		opts = model.PostMeasurement{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,8 @@ func checkCommandFormat() cobra.PositionalArgs {
 	}
 }
 
-func createContext(args []string) {
+func createContext(cmd string, args []string) {
+	ctx.Cmd = cmd // Get the command name
 	ctx.Target = args[0]
 
 	// If no from arg is provided, use the default value

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -49,20 +49,23 @@ func TestCreateContext(t *testing.T) {
 }
 
 func testContextNoArg(t *testing.T) {
-	createContext([]string{"1.1.1.1"})
+	createContext("test", []string{"1.1.1.1"})
+	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "world", ctx.From)
 }
 
 func testContextCountry(t *testing.T) {
-	createContext([]string{"1.1.1.1", "from", "Germany"})
+	createContext("test", []string{"1.1.1.1", "from", "Germany"})
+	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "Germany", ctx.From)
 }
 
 // Check if country with whitespace is parsed correctly
 func testContextCountryWhitespace(t *testing.T) {
-	createContext([]string{"1.1.1.1", "from", " Germany, France"})
+	createContext("test", []string{"1.1.1.1", "from", " Germany, France"})
+	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "Germany, France", ctx.From)
 }

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -20,7 +20,7 @@ var tracerouteCmd = &cobra.Command{
 	Args: checkCommandFormat(),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create context
-		createContext(args)
+		createContext(cmd.CalledAs(), args)
 
 		// Make post struct
 		opts = model.PostMeasurement{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,6 +14,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of Globalping CLI",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Globalping CLI " + version)
+		fmt.Println("Globalping CLI v" + version)
 	},
 }

--- a/model/get.go
+++ b/model/get.go
@@ -3,33 +3,19 @@ package model
 // Modeled from https://github.com/jsdelivr/globalping/blob/master/docs/measurement/get.md
 
 type ProbeData struct {
-	Continent string `json:"continent"`
-	Country   string `json:"country"`
-	City      string `json:"city"`
-	State     string `json:"state,omitempty"`
-	ASN       int    `json:"asn"`
-}
-
-type Timings struct {
-	TTL int `json:"ttl,omitempty"`
-	RTT int `json:"rtt,omitempty"`
-}
-
-type Stats struct {
-	Min  float32 `json:"min"`
-	Max  float32 `json:"max"`
-	Avg  float32 `json:"avg"`
-	Loss float32 `json:"loss"`
-}
-
-type ResultData struct {
-	RawOutput string `json:"rawOutput"`
+	Continent string   `json:"continent"`
+	Country   string   `json:"country"`
+	City      string   `json:"city"`
+	State     string   `json:"state,omitempty"`
+	ASN       int      `json:"asn"`
+	Network   string   `json:"network,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
 }
 
 // Nested structs
 type MeasurementResponse struct {
-	Probe  ProbeData  `json:"probe"`
-	Result ResultData `json:"result"`
+	Probe  ProbeData              `json:"probe"`
+	Result map[string]interface{} `json:"result"` // This is too dynamic depending on the type of measurement
 }
 
 // Main struct

--- a/model/get.go
+++ b/model/get.go
@@ -1,5 +1,7 @@
 package model
 
+import "encoding/json"
+
 // Modeled from https://github.com/jsdelivr/globalping/blob/master/docs/measurement/get.md
 
 type ProbeData struct {
@@ -13,14 +15,18 @@ type ProbeData struct {
 	Tags      []string `json:"tags,omitempty"`
 }
 
-// https://stackoverflow.com/questions/50092462/how-to-unmarshal-an-inconsistent-json-field-that-can-be-a-string-or-an-array-o
 type ResultData struct {
-	Status           string                   `json:"status"`
-	RawOutput        string                   `json:"rawOutput"`
-	ResolvedAddress  string                   `json:"resolvedAddress"`
-	ResolvedHostname string                   `json:"resolvedHostname"`
-	Timings          []map[string]interface{} `json:"timings,omitempty"`
-	Stats            map[string]interface{}   `json:"stats,omitempty"`
+	Status           string                 `json:"status"`
+	RawOutput        string                 `json:"rawOutput"`
+	ResolvedAddress  string                 `json:"resolvedAddress"`
+	ResolvedHostname string                 `json:"resolvedHostname"`
+	Stats            map[string]interface{} `json:"stats,omitempty"`
+	TimingsRaw       json.RawMessage        `json:"timings,omitempty"`
+}
+
+type Timings struct {
+	Arr       []map[string]interface{}
+	Interface map[string]interface{}
 }
 
 // Nested structs

--- a/model/get.go
+++ b/model/get.go
@@ -4,6 +4,7 @@ package model
 
 type ProbeData struct {
 	Continent string   `json:"continent"`
+	Region    string   `json:"region"`
 	Country   string   `json:"country"`
 	City      string   `json:"city"`
 	State     string   `json:"state,omitempty"`
@@ -12,18 +13,28 @@ type ProbeData struct {
 	Tags      []string `json:"tags,omitempty"`
 }
 
+type ResultData struct {
+	Status           string                   `json:"status"`
+	RawOutput        string                   `json:"rawOutput"`
+	ResolvedAddress  string                   `json:"resolvedAddress"`
+	ResolvedHostname string                   `json:"resolvedHostname"`
+	Timings          []map[string]interface{} `json:"timings,omitempty"`
+	Stats            map[string]interface{}   `json:"stats,omitempty"`
+}
+
 // Nested structs
 type MeasurementResponse struct {
-	Probe  ProbeData              `json:"probe"`
-	Result map[string]interface{} `json:"result"` // This is too dynamic depending on the type of measurement
+	Probe  ProbeData  `json:"probe"`
+	Result ResultData `json:"result"`
 }
 
 // Main struct
 type GetMeasurement struct {
-	ID        string                `json:"id"`
-	Type      string                `json:"type"`
-	Status    string                `json:"status"`
-	CreatedAt string                `json:"createdAt"`
-	UpdatedAt string                `json:"updatedAt"`
-	Results   []MeasurementResponse `json:"results"`
+	ID          string                `json:"id"`
+	Type        string                `json:"type"`
+	Status      string                `json:"status"`
+	CreatedAt   string                `json:"createdAt"`
+	UpdatedAt   string                `json:"updatedAt"`
+	ProbesCount int                   `json:"probesCount"`
+	Results     []MeasurementResponse `json:"results"`
 }

--- a/model/get.go
+++ b/model/get.go
@@ -2,18 +2,34 @@ package model
 
 // Modeled from https://github.com/jsdelivr/globalping/blob/master/docs/measurement/get.md
 
+type ProbeData struct {
+	Continent string `json:"continent"`
+	Country   string `json:"country"`
+	City      string `json:"city"`
+	State     string `json:"state,omitempty"`
+	ASN       int    `json:"asn"`
+}
+
+type Timings struct {
+	TTL int `json:"ttl,omitempty"`
+	RTT int `json:"rtt,omitempty"`
+}
+
+type Stats struct {
+	Min  float32 `json:"min"`
+	Max  float32 `json:"max"`
+	Avg  float32 `json:"avg"`
+	Loss float32 `json:"loss"`
+}
+
+type ResultData struct {
+	RawOutput string `json:"rawOutput"`
+}
+
 // Nested structs
 type MeasurementResponse struct {
-	Probe struct {
-		Continent string `json:"continent"`
-		Country   string `json:"country"`
-		City      string `json:"city"`
-		State     string `json:"state,omitempty"`
-		ASN       int    `json:"asn"`
-	} `json:"probe"`
-	Result struct {
-		RawOutput string `json:"rawOutput"`
-	} `json:"result"`
+	Probe  ProbeData  `json:"probe"`
+	Result ResultData `json:"result"`
 }
 
 // Main struct

--- a/model/get.go
+++ b/model/get.go
@@ -13,6 +13,7 @@ type ProbeData struct {
 	Tags      []string `json:"tags,omitempty"`
 }
 
+// https://stackoverflow.com/questions/50092462/how-to-unmarshal-an-inconsistent-json-field-that-can-be-a-string-or-an-array-o
 type ResultData struct {
 	Status           string                   `json:"status"`
 	RawOutput        string                   `json:"rawOutput"`

--- a/model/root.go
+++ b/model/root.go
@@ -2,6 +2,7 @@ package model
 
 // Used in thc client TUI
 type Context struct {
+	Cmd    string
 	Target string
 	From   string
 	Limit  int

--- a/model/root.go
+++ b/model/root.go
@@ -7,4 +7,6 @@ type Context struct {
 	Limit  int
 	// JsonOutput is a flag that determines whether the output should be in JSON format.
 	JsonOutput bool
+	// Latency is a flag that outputs only stats of a measurement
+	Latency bool
 }


### PR DESCRIPTION
Closes #8. Adds a new `--latency` flag to relevant commands as a method to quickly gather latency numbers.

Relevant screenshots:
**Ping**
![image](https://user-images.githubusercontent.com/38220115/220836790-fbe713ee-2fc6-40f8-8dce-b870d66b8626.png)
**DNS**
![image](https://user-images.githubusercontent.com/38220115/220837042-f5a48fd7-d59a-40cb-a38c-d6b96e9b626f.png)
**HTTP**
![image](https://user-images.githubusercontent.com/38220115/220837410-9d64f4a7-20f2-40ba-8ff5-f3632323393c.png)
