### PR TITLE
feat: add ci flag and make output pipeable

### DIFF
--- a/client/view.go
+++ b/client/view.go
@@ -20,25 +20,6 @@ var (
 	bold = lipgloss.NewStyle().Bold(true)
 )
 
-func dataSetup(id string) (model.GetMeasurement, error) {
-	// Get results
-	data, err := GetAPI(id)
-	if err != nil {
-		return data, err
-	}
-
-	// Probe may not have started yet
-	for len(data.Results) == 0 {
-		time.Sleep(100 * time.Millisecond)
-		data, err = GetAPI(id)
-		if err != nil {
-			return data, err
-		}
-	}
-
-	return data, nil
-}
-
 // Used to slice the output to fit the terminal in live view
 func sliceOutput(output string, w, h int) string {
 	// Split output into lines
@@ -230,10 +211,20 @@ func OutputCI(id string, data model.GetMeasurement, ctx model.Context) {
 
 func OutputResults(id string, ctx model.Context) {
 	// Wait for first result to arrive from a probe before starting display (can be in-progress)
-	data, err := dataSetup(id)
+	data, err := GetAPI(id)
 	if err != nil {
 		fmt.Println(err)
 		return
+	}
+
+	// Probe may not have started yet
+	for len(data.Results) == 0 {
+		time.Sleep(100 * time.Millisecond)
+		data, err = GetAPI(id)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
 	}
 
 	if ctx.CI || ctx.JsonOutput || ctx.Latency {

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,6 @@ func TestHttpCmd(t *testing.T) {
 
 func testParseUrl(t *testing.T) {
 	flags, _ := parseURL("https://cdn.jsdelivr.net:8080/npm/react/?query=3")
-	fmt.Printf("%+v", flags)
 	assert.Equal(t, "/npm/react/", flags.Path)
 	assert.Equal(t, "cdn.jsdelivr.net", flags.Host)
 	assert.Equal(t, "https", flags.Protocol)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&ctx.From, "from", "F", "", "A continent, region (e.g eastern europe), country, US state or city (default \"world\")")
 	rootCmd.PersistentFlags().IntVarP(&ctx.Limit, "limit", "L", 1, "Limit the number of probes to use")
 	rootCmd.PersistentFlags().BoolVarP(&ctx.JsonOutput, "json", "J", false, "Output results in JSON format (default false)")
-	rootCmd.PersistentFlags().BoolVarP(&ctx.CI, "ci", "C", false, "Output results in a format suitable for CI (default false)")
+	rootCmd.PersistentFlags().BoolVarP(&ctx.CI, "ci", "C", false, "Disable realtime terminal updates and color suitable for CI (default false)")
 }
 
 // checkCommandFormat checks if the command is in the correct format if using the from arg
@@ -90,6 +90,14 @@ func createContext(cmd string, args []string) error {
 	if os.Getenv("CI") != "" {
 		ctx.CI = true
 	}
+
+	// Check if it is a terminal or being piped/redirected
+	// We want to disable realtime updates if that is the case
+	o, _ := os.Stdout.Stat()
+	if (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
+		ctx.CI = true
+	}
+
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&ctx.From, "from", "F", "", "A continent, region (e.g eastern europe), country, US state or city (default \"world\")")
 	rootCmd.PersistentFlags().IntVarP(&ctx.Limit, "limit", "L", 1, "Limit the number of probes to use")
 	rootCmd.PersistentFlags().BoolVarP(&ctx.JsonOutput, "json", "J", false, "Output results in JSON format (default false)")
+	rootCmd.PersistentFlags().BoolVarP(&ctx.CI, "ci", "C", false, "Output results in a format suitable for CI (default false)")
 }
 
 // checkCommandFormat checks if the command is in the correct format if using the from arg
@@ -69,10 +70,10 @@ func checkCommandFormat() cobra.PositionalArgs {
 func createContext(cmd string, args []string) error {
 	ctx.Cmd = cmd // Get the command name
 
+	// Target
 	if len(args) == 0 {
 		return errors.New("provided target is empty")
 	}
-
 	ctx.Target = args[0]
 
 	// If no from arg is provided, use the default value
@@ -83,6 +84,11 @@ func createContext(cmd string, args []string) error {
 	// If from args are provided, use it
 	if len(args) > 1 && args[1] == "from" {
 		ctx.From = strings.TrimSpace(strings.Join(args[2:], " "))
+	}
+
+	// Check env for CI
+	if os.Getenv("CI") != "" {
+		ctx.CI = true
 	}
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -56,7 +56,6 @@ func testContextNoArg(t *testing.T) {
 	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "world", ctx.From)
-	assert.False(t, ctx.CI)
 	assert.NoError(t, err)
 }
 
@@ -65,7 +64,6 @@ func testContextCountry(t *testing.T) {
 	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "Germany", ctx.From)
-	assert.False(t, ctx.CI)
 	assert.NoError(t, err)
 }
 
@@ -75,7 +73,6 @@ func testContextCountryWhitespace(t *testing.T) {
 	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "Germany, France", ctx.From)
-	assert.False(t, ctx.CI)
 	assert.NoError(t, err)
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -42,6 +42,7 @@ func TestCreateContext(t *testing.T) {
 		"country":            testContextCountry,
 		"country_whitespace": testContextCountryWhitespace,
 		"no_target":          testContextNoTarget,
+		"ci_env":             testContextCIEnv,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			ctx = model.Context{}
@@ -55,6 +56,7 @@ func testContextNoArg(t *testing.T) {
 	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "world", ctx.From)
+	assert.False(t, ctx.CI)
 	assert.NoError(t, err)
 }
 
@@ -63,6 +65,7 @@ func testContextCountry(t *testing.T) {
 	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "Germany", ctx.From)
+	assert.False(t, ctx.CI)
 	assert.NoError(t, err)
 }
 
@@ -72,10 +75,21 @@ func testContextCountryWhitespace(t *testing.T) {
 	assert.Equal(t, "test", ctx.Cmd)
 	assert.Equal(t, "1.1.1.1", ctx.Target)
 	assert.Equal(t, "Germany, France", ctx.From)
+	assert.False(t, ctx.CI)
 	assert.NoError(t, err)
 }
 
 func testContextNoTarget(t *testing.T) {
 	err := createContext("test", []string{})
 	assert.Error(t, err)
+}
+
+func testContextCIEnv(t *testing.T) {
+	t.Setenv("CI", "true")
+	err := createContext("test", []string{"1.1.1.1"})
+	assert.Equal(t, "test", ctx.Cmd)
+	assert.Equal(t, "1.1.1.1", ctx.Target)
+	assert.Equal(t, "world", ctx.From)
+	assert.True(t, ctx.CI)
+	assert.NoError(t, err)
 }

--- a/model/root.go
+++ b/model/root.go
@@ -10,4 +10,6 @@ type Context struct {
 	JsonOutput bool
 	// Latency is a flag that outputs only stats of a measurement
 	Latency bool
+	// CI flag is used to determine whether the output should be in a format that is easy to parse by a CI tool
+	CI bool
 }


### PR DESCRIPTION
Closes #9. Adds a `--ci` flag that disables realtime updates and colour. This is also pipe-friendly output too.

The CI flag is automatically set to true if `env.CI` is set to true or the CLI detects the output is being redirected elsewhere.