### PR TITLE
feat: add isp names and regions to header output

### DIFF
--- a/client/view.go
+++ b/client/view.go
@@ -61,7 +61,7 @@ func generateHeader(result model.MeasurementResponse, ctx model.Context) string 
 		for _, tag := range result.Probe.Tags {
 			// If tag ends in a number, it's likely a region code and should be displayed
 			if _, err := strconv.Atoi(tag[len(tag)-1:]); err == nil {
-				output.WriteString(", " + tag)
+				output.WriteString(" " + tag)
 				break
 			}
 		}

--- a/client/view.go
+++ b/client/view.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,22 +47,30 @@ func sliceOutput(output string, w, h int) string {
 
 // Generate header that also checks if the probe has a state in it in the form %s, %s, (%s), %s, ASN:%d
 func generateHeader(result model.MeasurementResponse, ctx model.Context) string {
-	baseFormat := "%s, %s, %s, ASN:%d"
-	stateFormat := "%s, %s, (%s), %s, ASN:%d"
+	var output strings.Builder
 
-	// String builder for output
+	// Continent + Country + (State) + City + ASN + Network + (Region Tag)
+	output.WriteString(result.Probe.Continent + ", " + result.Probe.Country + ", ")
+	if result.Probe.State != "" {
+		output.WriteString("(" + result.Probe.State + "), ")
+	}
+	output.WriteString(result.Probe.City + ", ASN:" + fmt.Sprint(result.Probe.ASN) + ", " + result.Probe.Network)
+
+	// Check tags to see if there's a region code
+	if len(result.Probe.Tags) > 0 {
+		for _, tag := range result.Probe.Tags {
+			// If tag ends in a number, it's likely a region code and should be displayed
+			if _, err := strconv.Atoi(tag[len(tag)-1:]); err == nil {
+				output.WriteString(", " + tag)
+				break
+			}
+		}
+	}
+
 	if ctx.CI {
-		if result.Probe.State != "" {
-			return "> " + fmt.Sprintf(stateFormat, result.Probe.Continent, result.Probe.Country, result.Probe.State, result.Probe.City, result.Probe.ASN)
-		} else {
-			return "> " + fmt.Sprintf(baseFormat, result.Probe.Continent, result.Probe.Country, result.Probe.City, result.Probe.ASN)
-		}
+		return "> " + output.String()
 	} else {
-		if result.Probe.State != "" {
-			return arrow + highlight.Render(fmt.Sprintf(stateFormat, result.Probe.Continent, result.Probe.Country, result.Probe.State, result.Probe.City, result.Probe.ASN))
-		} else {
-			return arrow + highlight.Render(fmt.Sprintf(baseFormat, result.Probe.Continent, result.Probe.Country, result.Probe.City, result.Probe.ASN))
-		}
+		return arrow + highlight.Render(output.String())
 	}
 }
 

--- a/client/view.go
+++ b/client/view.go
@@ -61,7 +61,7 @@ func generateHeader(result model.MeasurementResponse, ctx model.Context) string 
 		for _, tag := range result.Probe.Tags {
 			// If tag ends in a number, it's likely a region code and should be displayed
 			if _, err := strconv.Atoi(tag[len(tag)-1:]); err == nil {
-				output.WriteString(" " + tag)
+				output.WriteString(" (" + tag + ")")
 				break
 			}
 		}

--- a/client/view_test.go
+++ b/client/view_test.go
@@ -45,8 +45,8 @@ func testHeadersTags(t *testing.T) {
 	newResult := testResult
 	newResult.Probe.Tags = []string{"tag1", "tag2"}
 
-	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network tag1", generateHeader(newResult, testContext))
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network (tag1)", generateHeader(newResult, testContext))
 
 	newResult.Probe.Tags = []string{"tag", "tag2"}
-	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network tag2", generateHeader(newResult, testContext))
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network (tag2)", generateHeader(newResult, testContext))
 }

--- a/client/view_test.go
+++ b/client/view_test.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateHeaders(t *testing.T) {
+	for scenario, fn := range map[string]func(t *testing.T){
+		"base": testHeadersBase,
+		"tags": testHeadersTags,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			fn(t)
+		})
+	}
+}
+
+var (
+	testContext = model.Context{
+		From:   "New York",
+		Target: "1.1.1.1",
+		CI:     true,
+	}
+	testResult = model.MeasurementResponse{
+		Probe: model.ProbeData{
+			Continent: "Continent",
+			Country:   "Country",
+			State:     "State",
+			City:      "City",
+			ASN:       12345,
+			Network:   "Network",
+			Tags:      []string{"tag"},
+		},
+	}
+)
+
+func testHeadersBase(t *testing.T) {
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network", generateHeader(testResult, testContext))
+}
+
+func testHeadersTags(t *testing.T) {
+	newResult := testResult
+	newResult.Probe.Tags = []string{"tag1", "tag2"}
+
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network, tag1", generateHeader(newResult, testContext))
+
+	newResult.Probe.Tags = []string{"tag", "tag2"}
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network, tag2", generateHeader(newResult, testContext))
+}

--- a/client/view_test.go
+++ b/client/view_test.go
@@ -45,8 +45,8 @@ func testHeadersTags(t *testing.T) {
 	newResult := testResult
 	newResult.Probe.Tags = []string{"tag1", "tag2"}
 
-	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network, tag1", generateHeader(newResult, testContext))
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network tag1", generateHeader(newResult, testContext))
 
 	newResult.Probe.Tags = []string{"tag", "tag2"}
-	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network, tag2", generateHeader(newResult, testContext))
+	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network tag2", generateHeader(newResult, testContext))
 }


### PR DESCRIPTION
Closes #7. @jimaek, let me know if the output looks good before I merge this.

**No tag**
![image](https://user-images.githubusercontent.com/38220115/221020509-561466d7-6ac5-4c30-9645-bdbd1e6cc753.png)

**With tag**
![image](https://user-images.githubusercontent.com/38220115/221020751-d77cbf0d-6eb6-47fa-a014-063be2b57cee.png)
![image](https://user-images.githubusercontent.com/38220115/221020820-d4dd53b8-b1d1-4d77-8fa5-13788f2990c3.png)

Will also make a corresponding PR for the Slack and Discord bots.