### PR TITLE
docs: add better examples and group help commands

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -12,13 +12,22 @@ import (
 var dnsCmd = &cobra.Command{
 	Use:     "dns [target] from [location]",
 	GroupID: "Measurements",
-	Short:   "Implementation of the native dig command",
+	Short:   "Use the native dig command",
 	Long: `Performs DNS lookups and displays the answers that are returned from the name server(s) that were queried. 
 The default nameserver depends on the probe and is defined by the user's local settings or DHCP.
 	
 Examples:
-# Resolve google.com from 2 probes in California
-dns google.com --from California --limit 2`,
+  # Resolve google.com from 2 probes in New York
+  dns google.com from New York --limit 2
+
+  # Resolve google.com from 2 probes from London or Belgium with trace enabled
+  dns google.com from London,Belgium --limit 2 --trace
+
+  # Resolve jsdelivr.com from a probe that is from the AWS network and is located in Montreal with latency output
+  dns jsdelivr.com from aws+montreal --latency
+
+  # Resolve jsdelivr.com with ASN 12345 with json output
+  dns jsdelivr.com from 12345 --json`,
 	Args: checkCommandFormat(),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create context

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -10,8 +10,9 @@ import (
 
 // dnsCmd represents the dns command
 var dnsCmd = &cobra.Command{
-	Use:   "dns [target] from [location]",
-	Short: "Implementation of the native dig command",
+	Use:     "dns [target] from [location]",
+	GroupID: "Measurements",
+	Short:   "Implementation of the native dig command",
 	Long: `Performs DNS lookups and displays the answers that are returned from the name server(s) that were queried. 
 The default nameserver depends on the probe and is defined by the user's local settings or DHCP.
 	

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -60,12 +60,21 @@ func overrideOptInt(orig, new int) int {
 var httpCmd = &cobra.Command{
 	Use:     "http [target] from [location]",
 	GroupID: "Measurements",
-	Short:   "Use http command",
+	Short:   "Perform a HEAD or GET request to a host",
 	Long: `The http command sends an HTTP request to a host and can perform HEAD or GET operations. GET is limited to 10KB responses, everything above will be cut by the API.
 	
 Examples:
-# HTTP HEAD request to jsdelivr.com from 2 probes in New York
-http https://www.jsdelivr.com/package/npm/test?nav=stats --from "New York" --limit 2`,
+  # HTTP HEAD request to jsdelivr.com from 2 probes in New York (protocol, port and path are inferred from the URL)
+  http https://www.jsdelivr.com:443/package/npm/test?nav=stats from New York --limit 2
+
+  # HTTP GET request to google.com from 2 probes from London or Belgium
+  http google.com from London,Belgium --limit 2 --method get
+
+  # HTTP HEAD request to jsdelivr.com from a probe that is from the AWS network and is located in Montreal using HTTP2
+  http jsdelivr.com from aws+montreal --protocol http2
+
+  # HTTP GET request google.com with ASN 12345 with json output
+  http google.com from 12345 --json`,
 	Args: checkCommandFormat(),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create context
@@ -121,7 +130,7 @@ func init() {
 	httpCmd.Flags().StringVar(&path, "path", "", "A URL pathname (default \"/\")")
 	httpCmd.Flags().StringVar(&query, "query", "", "A query-string")
 	httpCmd.Flags().StringVar(&host, "host", "", "Specifies the Host header, which is going to be added to the request (default host defined in target)")
-	httpCmd.Flags().StringVar(&method, "method", "", "Specifies the HTTP method to use (HEAD or GET).(default \"HEAD\")")
+	httpCmd.Flags().StringVar(&method, "method", "", "Specifies the HTTP method to use (HEAD or GET) (default \"HEAD\")")
 	httpCmd.Flags().StringVar(&protocol, "protocol", "", "Specifies the query protocol (HTTP, HTTPS, HTTP2) (default \"HTTP\")")
 	httpCmd.Flags().IntVar(&port, "port", 0, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
 	httpCmd.Flags().StringVar(&resolver, "resolver", "", "Specifies the resolver server used for DNS lookup")

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -58,8 +58,9 @@ func overrideOptInt(orig, new int) int {
 
 // httpCmd represents the http command
 var httpCmd = &cobra.Command{
-	Use:   "http [target] from [location]",
-	Short: "Use http command",
+	Use:     "http [target] from [location]",
+	GroupID: "Measurements",
+	Short:   "Use http command",
 	Long: `The http command sends an HTTP request to a host and can perform HEAD or GET operations. GET is limited to 10KB responses, everything above will be cut by the API.
 	
 Examples:

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -12,12 +12,21 @@ import (
 var mtrCmd = &cobra.Command{
 	Use:     "mtr [target] from [location]",
 	GroupID: "Measurements",
-	Short:   "Implementation of the native mtr command",
+	Short:   "Use the native mtr command",
 	Long: `mtr combines the functionality of the traceroute and ping programs in a single network diagnostic tool.
 	
 Examples:
-# MTR google.com from 2 probes in New York
-mtr google.com --from "New York" --limit 2`,
+  # MTR google.com from 2 probes in New York
+  mtr google.com from New York --limit 2
+
+  # MTR 1.1.1.1 from 2 probes from North America or Belgium with 10 packets
+  mtr 1.1.1.1 from North America,Belgium --limit 2 --packets 10
+
+  # MTR jsdelivr.com from a probe that is from the AWS network and is located in Montreal using the TCP protocol
+  mtr jsdelivr.com from aws+montreal --protocol tcp
+
+  # MTR jsdelivr.com with ASN 12345 with json output
+  mtr jsdelivr.com from 12345 --json`,
 	Args: checkCommandFormat(),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create context

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -10,8 +10,9 @@ import (
 
 // mtrCmd represents the mtr command
 var mtrCmd = &cobra.Command{
-	Use:   "mtr [target] from [location]",
-	Short: "Implementation of the native mtr command",
+	Use:     "mtr [target] from [location]",
+	GroupID: "Measurements",
+	Short:   "Implementation of the native mtr command",
 	Long: `mtr combines the functionality of the traceroute and ping programs in a single network diagnostic tool.
 	
 Examples:

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -12,12 +12,21 @@ import (
 var pingCmd = &cobra.Command{
 	Use:     "ping [target] from [location]",
 	GroupID: "Measurements",
-	Short:   "Use ping command",
+	Short:   "Use the native ping command",
 	Long: `The ping command sends an ICMP ECHO_REQUEST to obtain an ICMP ECHO_RESPONSE from a host or gateway.
 	
 Examples:
-# Ping google.com from 2 probes in New York
-ping google.com --from "New York" --limit 2`,
+  # Ping google.com from 2 probes in New York
+  ping google.com from New York --limit 2
+
+  # Ping 1.1.1.1 from 2 probes from North America or Belgium with 10 packets
+  ping 1.1.1.1 from North America,Belgium --limit 2 --packets 10
+
+  # Ping jsdelivr.com from a probe that is from the AWS network and is located in Montreal with latency output
+  ping jsdelivr.com from aws+montreal --latency
+
+  # Ping jsdelivr.com with ASN 12345 with json output
+  ping jsdelivr.com from 12345 --json`,
 	Args: checkCommandFormat(),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create context
@@ -58,5 +67,5 @@ func init() {
 	pingCmd.Flags().IntVar(&packets, "packets", 0, "Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)")
 
 	// Extra flags
-	pingCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only stats of a measurement (default false)")
+	pingCmd.Flags().BoolVar(&ctx.Latency, "latency", false, "Output only the stats of a measurement (default false)")
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -10,8 +10,9 @@ import (
 
 // pingCmd represents the ping command
 var pingCmd = &cobra.Command{
-	Use:   "ping [target] from [location]",
-	Short: "Use ping command",
+	Use:     "ping [target] from [location]",
+	GroupID: "Measurements",
+	Short:   "Use ping command",
 	Long: `The ping command sends an ICMP ECHO_REQUEST to obtain an ICMP ECHO_RESPONSE from a host or gateway.
 	
 Examples:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,8 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(ver string) {
 	version = ver
+
+	rootCmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -12,12 +12,21 @@ import (
 var tracerouteCmd = &cobra.Command{
 	Use:     "traceroute [target] from [location]",
 	GroupID: "Measurements",
-	Short:   "Implementation of the native traceroute command",
+	Short:   "Use the native traceroute command",
 	Long: `traceroute tracks the route packets taken from an IP network on their way to a given host. It utilizes the IP protocol's time to live (TTL) field and attempts to elicit an ICMP TIME_EXCEEDED response from each gateway along the path to the host.
 	
 Examples:
-# Traceroute google.com from 2 probes in New York
-traceroute google.com --from "New York" --limit 2`,
+  # Traceroute google.com from 2 probes in New York
+  traceroute google.com from New York --limit 2
+
+  # Traceroute 1.1.1.1 from 2 probes from North America or Belgium
+  traceroute 1.1.1.1 from North America,Belgium --limit 2
+
+  # Traceroute jsdelivr.com from a probe that is from the AWS network and is located in Montreal using the UDP protocol
+  traceroute jsdelivr.com from aws+montreal --protocol udp
+
+  # Traceroute jsdelivr.com with ASN 12345 with json output
+  traceroute jsdelivr.com from 12345 --json`,
 	Args: checkCommandFormat(),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create context

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -10,8 +10,9 @@ import (
 
 // tracerouteCmd represents the traceroute command
 var tracerouteCmd = &cobra.Command{
-	Use:   "traceroute [target] from [location]",
-	Short: "Implementation of the native traceroute command",
+	Use:     "traceroute [target] from [location]",
+	GroupID: "Measurements",
+	Short:   "Implementation of the native traceroute command",
 	Long: `traceroute tracks the route packets taken from an IP network on their way to a given host. It utilizes the IP protocol's time to live (TTL) field and attempts to elicit an ICMP TIME_EXCEEDED response from each gateway along the path to the host.
 	
 Examples:


### PR DESCRIPTION
Partially improves #16. Adds more examples for each help command and also groups the main help command with measurements in one section and other commands (e.g. version or help) in another.