### PR TITLE
HTTP fixes/refactor

### DIFF
--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -6,27 +6,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHttpCmd(t *testing.T) {
-	for scenario, fn := range map[string]func(t *testing.T){
-		"parseUrl":    testParseUrl,
-		"overrideOpt": testOverrideOpt,
-	} {
-		t.Run(scenario, func(t *testing.T) {
-			fn(t)
-		})
-	}
+func TestParseUrlData(t *testing.T) {
+	urlData, err := parseUrlData("https://cdn.jsdelivr.net:8080/npm/react/?query=3")
+	assert.NoError(t, err)
+	assert.Equal(t, "cdn.jsdelivr.net", urlData.Host)
+	assert.Equal(t, "/npm/react/", urlData.Path)
+	assert.Equal(t, "https", urlData.Protocol)
+	assert.Equal(t, 8080, urlData.Port)
+	assert.Equal(t, "query=3", urlData.Query)
 }
 
-func testParseUrl(t *testing.T) {
-	flags, _ := parseURL("https://cdn.jsdelivr.net:8080/npm/react/?query=3")
-	assert.Equal(t, "/npm/react/", flags.Path)
-	assert.Equal(t, "cdn.jsdelivr.net", flags.Host)
-	assert.Equal(t, "https", flags.Protocol)
-	assert.Equal(t, 8080, flags.Port)
-	assert.Equal(t, "query=3", flags.Query)
+func TestParseUrlDataNoScheme(t *testing.T) {
+	urlData, err := parseUrlData("cdn.jsdelivr.net/npm/react/?query=3")
+	assert.NoError(t, err)
+	assert.Equal(t, "cdn.jsdelivr.net", urlData.Host)
+	assert.Equal(t, "/npm/react/", urlData.Path)
+	assert.Equal(t, "http", urlData.Protocol)
+	assert.Equal(t, 0, urlData.Port)
+	assert.Equal(t, "query=3", urlData.Query)
 }
 
-func testOverrideOpt(t *testing.T) {
+func TestParseUrlDataHostOnly(t *testing.T) {
+	urlData, err := parseUrlData("cdn.jsdelivr.net")
+	assert.NoError(t, err)
+	assert.Equal(t, "cdn.jsdelivr.net", urlData.Host)
+	assert.Equal(t, "", urlData.Path)
+	assert.Equal(t, "http", urlData.Protocol)
+	assert.Equal(t, 0, urlData.Port)
+	assert.Equal(t, "", urlData.Query)
+}
+
+func TestOverrideOpt(t *testing.T) {
 	assert.Equal(t, "new", overrideOpt("orig", "new"))
 	assert.Equal(t, "orig", overrideOpt("orig", ""))
 	assert.Equal(t, 10, overrideOptInt(0, 10))

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 // indirect
 	github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIW
 github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0 h1:STjmj0uFfRryL9fzRA/OupNppeAID6QJYPMavTL7jtY=
 github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pterm/pterm v0.12.27/go.mod h1:PhQ89w4i95rhgE+xedAoqous6K9X+r6aSOI2eFF7DZI=


### PR DESCRIPTION
Fixes #30 
- some refactorings and renamings for clarity
- autoparses the command format `globalping http https://domain.com/path?query`
- arguments such as `--path` take precedence over fields parsed from url

Some general comments:
- We could add a linter (https://github.com/golangci/golangci-lint)
- As it's customary in Go projects, we could add a Makefile with cli run, test, lint commands 
- We could add a verbose mode to allow observability into the request that is posted by printing the full post data before posting to globalping API
- I find that there is too much usage of global/package level variables (for example the "opts" variable, "path", etc), it makes unit testing harder, it's also error prone as it's more difficult to follow the code logic and it's easy to shadow the variables without realising. This could benefit from a refactor