### PR TITLE
Implement guidelines

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/jsdelivr/globalping-cli/model"
@@ -97,79 +96,4 @@ func DecodeTimings(cmd string, timings json.RawMessage) (model.Timings, error) {
 	}
 
 	return data, nil
-}
-
-// Get measurement from Globalping API
-func GetAPI(id string) (model.GetMeasurement, error) {
-	// Create a new request
-	req, err := http.NewRequest("GET", ApiUrl+"/"+id, nil)
-	if err != nil {
-		return model.GetMeasurement{}, errors.New("err: failed to create request")
-	}
-	req.Header.Set("User-Agent", userAgent())
-	req.Header.Set("Accept-Encoding", "br")
-
-	// Make the request
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return model.GetMeasurement{}, errors.New("err: request failed")
-	}
-	defer resp.Body.Close()
-
-	// 404 not found
-	if resp.StatusCode == http.StatusNotFound {
-		return model.GetMeasurement{}, errors.New("err: measurement not found")
-	}
-
-	// 500 error
-	if resp.StatusCode == http.StatusInternalServerError {
-		return model.GetMeasurement{}, errors.New("err: internal server error - please try again later")
-	}
-
-	// Read the response body
-	var data model.GetMeasurement
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		return model.GetMeasurement{}, errors.New("invalid get measurement format returned")
-	}
-
-	return data, nil
-}
-
-func GetApiJson(id string) (string, error) {
-	// Create a new request
-	req, err := http.NewRequest("GET", ApiUrl+"/"+id, nil)
-	if err != nil {
-		return "", errors.New("err: failed to create request")
-	}
-	req.Header.Set("User-Agent", userAgent())
-	req.Header.Set("Accept-Encoding", "br")
-
-	// Make the request
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", errors.New("err: request failed")
-	}
-	defer resp.Body.Close()
-
-	// 404 not found
-	if resp.StatusCode == http.StatusNotFound {
-		return "", errors.New("err: measurement not found")
-	}
-
-	// 500 error
-	if resp.StatusCode == http.StatusInternalServerError {
-		return "", errors.New("err: internal server error - please try again later")
-	}
-
-	// Read the response body
-	respBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", errors.New("err: failed to read response body")
-	}
-	respString := string(respBytes)
-
-	return respString, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -107,6 +107,7 @@ func GetAPI(id string) (model.GetMeasurement, error) {
 		return model.GetMeasurement{}, errors.New("err: failed to create request")
 	}
 	req.Header.Set("User-Agent", userAgent())
+	req.Header.Set("Accept-Encoding", "br")
 
 	// Make the request
 	client := &http.Client{}
@@ -143,6 +144,7 @@ func GetApiJson(id string) (string, error) {
 		return "", errors.New("err: failed to create request")
 	}
 	req.Header.Set("User-Agent", userAgent())
+	req.Header.Set("Accept-Encoding", "br")
 
 	// Make the request
 	client := &http.Client{}

--- a/client/client.go
+++ b/client/client.go
@@ -7,12 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"runtime"
 
 	"github.com/jsdelivr/globalping-cli/model"
 )
-
-const userAgent = "Globalping API Go Client / v1" + " (" + runtime.GOOS + "/" + runtime.GOARCH + ")"
 
 var ApiUrl = "https://api.globalping.io/v1/measurements"
 
@@ -29,7 +26,7 @@ func PostAPI(measurement model.PostMeasurement) (model.PostResponse, bool, error
 	if err != nil {
 		return model.PostResponse{}, false, errors.New("err: failed to create request - please report this bug")
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent())
 	req.Header.Set("Content-Type", "application/json")
 
 	// Make the request
@@ -108,7 +105,7 @@ func GetAPI(id string) (model.GetMeasurement, error) {
 	if err != nil {
 		return model.GetMeasurement{}, errors.New("err: failed to create request")
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent())
 
 	// Make the request
 	client := &http.Client{}
@@ -144,7 +141,7 @@ func GetApiJson(id string) (string, error) {
 	if err != nil {
 		return "", errors.New("err: failed to create request")
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent())
 
 	// Make the request
 	client := &http.Client{}

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,7 @@ func PostAPI(measurement model.PostMeasurement) (model.PostResponse, bool, error
 		return model.PostResponse{}, false, errors.New("err: failed to create request - please report this bug")
 	}
 	req.Header.Set("User-Agent", userAgent())
+	req.Header.Set("Accept-Encoding", "br")
 	req.Header.Set("Content-Type", "application/json")
 
 	// Make the request

--- a/client/client.go
+++ b/client/client.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
+	"github.com/andybalholm/brotli"
 	"github.com/jsdelivr/globalping-cli/model"
 )
 
@@ -70,8 +72,14 @@ func PostAPI(measurement model.PostMeasurement) (model.PostResponse, bool, error
 	}
 
 	// Read the response body
+
+	var bodyReader io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "br" {
+		bodyReader = brotli.NewReader(bodyReader)
+	}
+
 	var data model.PostResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	err = json.NewDecoder(bodyReader).Decode(&data)
 	if err != nil {
 		fmt.Println(err)
 		return model.PostResponse{}, false, errors.New("err: invalid post measurement format returned - please report this bug")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -137,7 +137,9 @@ func testGetValid(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetAPI("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -152,12 +154,14 @@ func testGetJson(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetApiJson("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetRawMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, `{"id":"abcd"}`, res)
+	assert.Equal(t, `{"id":"abcd"}`, string(res))
 }
 
 func testGetPing(t *testing.T) {
@@ -206,7 +210,9 @@ func testGetPing(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetAPI("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -299,7 +305,9 @@ func testGetTraceroute(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetAPI("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -375,7 +383,9 @@ func testGetDns(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetAPI("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -498,7 +508,9 @@ func testGetMtr(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetAPI("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}
@@ -603,7 +615,9 @@ func testGetHttp(t *testing.T) {
 	defer server.Close()
 	client.ApiUrl = server.URL
 
-	res, err := client.GetAPI("abcd")
+	fetcher := client.NewMeasurementsFetcher(server.URL)
+
+	res, err := fetcher.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
 	}

--- a/client/measurements_fetcher.go
+++ b/client/measurements_fetcher.go
@@ -99,6 +99,10 @@ func (f *measurementsFetcher) GetRawMeasurement(id string) ([]byte, error) {
 		return respBytes, nil
 	}
 
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("err: response code %d", resp.StatusCode)
+	}
+
 	var bodyReader io.Reader = resp.Body
 
 	if resp.Header.Get("Content-Encoding") == "br" {

--- a/client/measurements_fetcher.go
+++ b/client/measurements_fetcher.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/andybalholm/brotli"
+	"github.com/jsdelivr/globalping-cli/model"
+)
+
+type MeasurementsFetcher interface {
+	GetMeasurement(id string) (*model.GetMeasurement, error)
+	GetRawMeasurement(id string) ([]byte, error)
+}
+
+type measurementsFetcher struct {
+	// The api url endpoint
+	apiUrl string
+
+	// http client
+	cl *http.Client
+
+	// caches Etags by measurement id
+	etags map[string]string
+
+	// caches Measurements by ETag
+	measurements map[string][]byte
+}
+
+func NewMeasurementsFetcher(apiUrl string) *measurementsFetcher {
+	return &measurementsFetcher{
+		apiUrl:       apiUrl,
+		cl:           &http.Client{},
+		etags:        map[string]string{},
+		measurements: map[string][]byte{},
+	}
+}
+
+// GetRawMeasurement returns API response as a GetMeasurement object
+func (f *measurementsFetcher) GetMeasurement(id string) (*model.GetMeasurement, error) {
+	respBytes, err := f.GetRawMeasurement(id)
+	if err != nil {
+		return nil, err
+	}
+
+	var m model.GetMeasurement
+	err = json.Unmarshal(respBytes, &m)
+	if err != nil {
+		return nil, fmt.Errorf("invalid get measurement format returned: %v %s", err, string(respBytes))
+	}
+
+	return &m, nil
+}
+
+// GetRawMeasurement returns the API response's raw json response
+func (f *measurementsFetcher) GetRawMeasurement(id string) ([]byte, error) {
+	// Create a new request
+	req, err := http.NewRequest("GET", f.apiUrl+"/"+id, nil)
+	if err != nil {
+		return nil, errors.New("err: failed to create request")
+	}
+
+	req.Header.Set("User-Agent", userAgent())
+	req.Header.Set("Accept-Encoding", "br")
+
+	etag := f.etags[id]
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	// Make the request
+	resp, err := f.cl.Do(req)
+	if err != nil {
+		return nil, errors.New("err: request failed")
+	}
+	defer resp.Body.Close()
+
+	// 404 not found
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errors.New("err: measurement not found")
+	}
+
+	// 500 error
+	if resp.StatusCode == http.StatusInternalServerError {
+		return nil, errors.New("err: internal server error - please try again later")
+	}
+
+	// 304 not modified
+	if resp.StatusCode == http.StatusNotModified {
+		// get response bytes from cache
+		respBytes := f.measurements[etag]
+		if respBytes == nil {
+			return nil, errors.New("err: response not found in etags cache")
+		}
+
+		return respBytes, nil
+	}
+
+	var bodyReader io.Reader = resp.Body
+
+	if resp.Header.Get("Content-Encoding") == "br" {
+		bodyReader = brotli.NewReader(bodyReader)
+	}
+
+	// Read the response body
+	respBytes, err := io.ReadAll(bodyReader)
+	if err != nil {
+		return nil, errors.New("err: failed to read response body")
+	}
+
+	// save etag and response to cache
+	etag = resp.Header.Get("ETag")
+	f.etags[id] = etag
+	f.measurements[etag] = respBytes
+
+	return respBytes, nil
+}

--- a/client/measurements_fetcher_test.go
+++ b/client/measurements_fetcher_test.go
@@ -1,0 +1,11 @@
+package client
+
+import "testing"
+
+func TestFetchWithBrotli(t *testing.T) {
+	t.Fatalf("not implemented")
+}
+
+func TestFetchWithEtag(t *testing.T) {
+	t.Fatalf("not implemented")
+}

--- a/client/measurements_fetcher_test.go
+++ b/client/measurements_fetcher_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andybalholm/brotli"
 	"github.com/jsdelivr/globalping-cli/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -69,4 +70,34 @@ func TestFetchWithEtag(t *testing.T) {
 
 	assert.Equal(t, 1, cacheHitCount)
 	assert.Equal(t, 2, cacheMissCount)
+}
+
+func TestFetchWithBrotli(t *testing.T) {
+	id := "123abc"
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		id := parts[len(parts)-1]
+
+		assert.Equal(t, "br", r.Header.Get("Accept-Encoding"))
+
+		m := &model.GetMeasurement{
+			ID: id,
+		}
+
+		w.Header().Set("Content-Encoding", "br")
+
+		rW := brotli.NewWriter(w)
+		defer rW.Close()
+
+		err := json.NewEncoder(rW).Encode(m)
+		assert.NoError(t, err)
+	}))
+
+	f := NewMeasurementsFetcher(s.URL)
+
+	m, err := f.GetMeasurement(id)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id, m.ID)
 }

--- a/client/measurements_fetcher_test.go
+++ b/client/measurements_fetcher_test.go
@@ -1,11 +1,72 @@
 package client
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-func TestFetchWithBrotli(t *testing.T) {
-	t.Fatalf("not implemented")
-}
+	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestFetchWithEtag(t *testing.T) {
-	t.Fatalf("not implemented")
+	id1 := "123abc"
+	id2 := "567xyz"
+
+	cacheMissCount := 0
+	cacheHitCount := 0
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		id := parts[len(parts)-1]
+
+		etag := func(id string) string {
+			return "etag-" + id
+		}
+
+		if r.Header.Get("If-None-Match") == etag(id) {
+			// cache hit
+			cacheHitCount++
+			w.Header().Set("ETag", etag(id))
+			w.WriteHeader(http.StatusNotModified)
+
+			return
+		}
+
+		// cache miss, return full response
+		cacheMissCount++
+		m := &model.GetMeasurement{
+			ID: id,
+		}
+
+		w.Header().Set("ETag", etag(id))
+
+		err := json.NewEncoder(w).Encode(m)
+		assert.NoError(t, err)
+	}))
+
+	f := NewMeasurementsFetcher(s.URL)
+
+	// first request for id1
+	m, err := f.GetMeasurement(id1)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id1, m.ID)
+
+	// first request for id1
+	m, err = f.GetMeasurement(id2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id2, m.ID)
+
+	// second request for id1
+	m, err = f.GetMeasurement(id2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id2, m.ID)
+
+	assert.Equal(t, 1, cacheHitCount)
+	assert.Equal(t, 2, cacheMissCount)
 }

--- a/client/user_agent.go
+++ b/client/user_agent.go
@@ -1,0 +1,11 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/jsdelivr/globalping-cli/version"
+)
+
+func userAgent() string {
+	return fmt.Sprintf("globalping-cli/%s (https://github.com/jsdelivr/globalping-cli)", version.Version)
+}

--- a/client/user_agent.go
+++ b/client/user_agent.go
@@ -7,5 +7,5 @@ import (
 )
 
 func userAgent() string {
-	return fmt.Sprintf("globalping-cli/%s (https://github.com/jsdelivr/globalping-cli)", version.Version)
+	return fmt.Sprintf("globalping-cli/v%s (https://github.com/jsdelivr/globalping-cli)", version.Version)
 }

--- a/client/user_agent_test.go
+++ b/client/user_agent_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/jsdelivr/globalping-cli/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserAgent(t *testing.T) {
+	version.Version = "x.y.z"
+	assert.Equal(t, "globalping-cli/vx.y.z (https://github.com/jsdelivr/globalping-cli)", userAgent())
+}

--- a/client/view.go
+++ b/client/view.go
@@ -74,7 +74,7 @@ func generateHeader(result model.MeasurementResponse, ctx model.Context) string 
 	}
 }
 
-var liveViewPollInterval = 100 * time.Millisecond
+var apiPollInterval = 1000 * time.Millisecond
 
 func LiveView(id string, data model.GetMeasurement, ctx model.Context) {
 	var err error
@@ -106,7 +106,7 @@ func LiveView(id string, data model.GetMeasurement, ctx model.Context) {
 
 	// Poll API until the measurement is complete
 	for data.Status == "in-progress" {
-		time.Sleep(liveViewPollInterval)
+		time.Sleep(apiPollInterval)
 		data, err = GetAPI(id)
 		if err != nil {
 			fmt.Printf("failed to get data: %v\n", err)
@@ -249,7 +249,7 @@ func OutputResults(id string, ctx model.Context) {
 
 	// Probe may not have started yet
 	for len(data.Results) == 0 {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(apiPollInterval)
 		data, err = GetAPI(id)
 		if err != nil {
 			fmt.Println(err)
@@ -258,9 +258,9 @@ func OutputResults(id string, ctx model.Context) {
 	}
 
 	if ctx.CI || ctx.JsonOutput || ctx.Latency {
-		// Poll API every 100 milliseconds until the measurement is complete
+		// Poll API until the measurement is complete
 		for data.Status == "in-progress" {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(apiPollInterval)
 			data, err = GetAPI(id)
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jsdelivr/globalping-cli/client"
 	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +71,7 @@ Examples:
 			return nil
 		}
 
-		client.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx)
 		return nil
 	},
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jsdelivr/globalping-cli/client"
 	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -136,7 +137,7 @@ func httpCmdRun(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	client.OutputResults(res.ID, ctx)
+	view.OutputResults(res.ID, ctx)
 	return nil
 }
 

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jsdelivr/globalping-cli/client"
 	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -62,7 +63,7 @@ Examples:
 			return nil
 		}
 
-		client.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx)
 		return nil
 	},
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jsdelivr/globalping-cli/client"
 	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +57,7 @@ Examples:
 			return nil
 		}
 
-		client.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx)
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,8 @@ var (
 
 	// TODO: headers   map[string]string
 
-	opts    = model.PostMeasurement{}
-	ctx     = model.Context{}
-	version string
+	opts = model.PostMeasurement{}
+	ctx  = model.Context{}
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -40,9 +39,7 @@ The CLI tool allows you to interact with the API in a simple and human-friendly 
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(ver string) {
-	version = ver
-
+func Execute() {
 	rootCmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})
 	err := rootCmd.Execute()
 	if err != nil {

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jsdelivr/globalping-cli/client"
 	"github.com/jsdelivr/globalping-cli/model"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +65,7 @@ Examples:
 			return nil
 		}
 
-		client.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx)
 		return nil
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/jsdelivr/globalping-cli/version"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of Globalping CLI",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Globalping CLI v" + version)
+		fmt.Println("Globalping CLI v" + version.Version)
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	atomicgo.dev/cursor v0.1.1 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect
+	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/MarvinJWendt/testza v0.2.12/go.mod h1:JOIegYyV7rX+7VZ9r77L/eH6CfJHHzX
 github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/2oUqKc6bF2c=
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/MarvinJWendt/testza v0.5.2 h1:53KDo64C1z/h/d/stCYCPY69bt/OSwjq5KpFNwi+zB4=
+github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
+github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/jsdelivr/globalping-cli/cmd"
+import (
+	"github.com/jsdelivr/globalping-cli/cmd"
+	pkgversion "github.com/jsdelivr/globalping-cli/version"
+)
 
 var (
 	// https://goreleaser.com/cookbooks/using-main.version/
@@ -8,5 +11,6 @@ var (
 )
 
 func main() {
-	cmd.Execute(version)
+	pkgversion.Version = version
+	cmd.Execute()
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Tool Version
+var Version string

--- a/view/view.go
+++ b/view/view.go
@@ -75,7 +75,7 @@ func generateHeader(result model.MeasurementResponse, ctx model.Context) string 
 	}
 }
 
-var apiPollInterval = 1000 * time.Millisecond
+var apiPollInterval = 500 * time.Millisecond
 
 func LiveView(id string, data *model.GetMeasurement, ctx model.Context) {
 	var err error

--- a/view/view.go
+++ b/view/view.go
@@ -1,4 +1,4 @@
-package client
+package view
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jsdelivr/globalping-cli/client"
 	"github.com/jsdelivr/globalping-cli/model"
 	"github.com/pterm/pterm"
 )
@@ -76,7 +77,7 @@ func generateHeader(result model.MeasurementResponse, ctx model.Context) string 
 
 var apiPollInterval = 1000 * time.Millisecond
 
-func LiveView(id string, data model.GetMeasurement, ctx model.Context) {
+func LiveView(id string, data *model.GetMeasurement, ctx model.Context) {
 	var err error
 
 	// Create new writer
@@ -104,10 +105,12 @@ func LiveView(id string, data model.GetMeasurement, ctx model.Context) {
 	// String builder for output
 	var output strings.Builder
 
+	fetcher := client.NewMeasurementsFetcher(client.ApiUrl)
+
 	// Poll API until the measurement is complete
 	for data.Status == "in-progress" {
 		time.Sleep(apiPollInterval)
-		data, err = GetAPI(id)
+		data, err = fetcher.GetMeasurement(id)
 		if err != nil {
 			fmt.Printf("failed to get data: %v\n", err)
 			return
@@ -139,17 +142,17 @@ func LiveView(id string, data model.GetMeasurement, ctx model.Context) {
 }
 
 // If json flag is used, only output json
-func OutputJson(id string) {
-	output, err := GetApiJson(id)
+func OutputJson(id string, fetcher client.MeasurementsFetcher) {
+	output, err := fetcher.GetRawMeasurement(id)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	fmt.Println(output)
+	fmt.Println(string(output))
 }
 
 // If latency flag is used, only output latency values
-func OutputLatency(id string, data model.GetMeasurement, ctx model.Context) {
+func OutputLatency(id string, data *model.GetMeasurement, ctx model.Context) {
 	// String builder for output
 	var output strings.Builder
 
@@ -166,7 +169,7 @@ func OutputLatency(id string, data model.GetMeasurement, ctx model.Context) {
 			}
 
 			if ctx.Cmd == "dns" {
-				timings, err := DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
+				timings, err := client.DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
 				if err != nil {
 					fmt.Println(err)
 					return
@@ -175,7 +178,7 @@ func OutputLatency(id string, data model.GetMeasurement, ctx model.Context) {
 			}
 
 			if ctx.Cmd == "http" {
-				timings, err := DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
+				timings, err := client.DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
 				if err != nil {
 					fmt.Println(err)
 					return
@@ -195,7 +198,7 @@ func OutputLatency(id string, data model.GetMeasurement, ctx model.Context) {
 			}
 
 			if ctx.Cmd == "dns" {
-				timings, err := DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
+				timings, err := client.DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
 				if err != nil {
 					fmt.Println(err)
 					return
@@ -204,7 +207,7 @@ func OutputLatency(id string, data model.GetMeasurement, ctx model.Context) {
 			}
 
 			if ctx.Cmd == "http" {
-				timings, err := DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
+				timings, err := client.DecodeTimings(ctx.Cmd, result.Result.TimingsRaw)
 				if err != nil {
 					fmt.Println(err)
 					return
@@ -223,7 +226,7 @@ func OutputLatency(id string, data model.GetMeasurement, ctx model.Context) {
 	fmt.Println(strings.TrimSpace(output.String()))
 }
 
-func OutputCI(id string, data model.GetMeasurement, ctx model.Context) {
+func OutputCI(id string, data *model.GetMeasurement, ctx model.Context) {
 	// String builder for output
 	var output strings.Builder
 
@@ -240,8 +243,10 @@ func OutputCI(id string, data model.GetMeasurement, ctx model.Context) {
 }
 
 func OutputResults(id string, ctx model.Context) {
+	fetcher := client.NewMeasurementsFetcher(client.ApiUrl)
+
 	// Wait for first result to arrive from a probe before starting display (can be in-progress)
-	data, err := GetAPI(id)
+	data, err := fetcher.GetMeasurement(id)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -250,7 +255,7 @@ func OutputResults(id string, ctx model.Context) {
 	// Probe may not have started yet
 	for len(data.Results) == 0 {
 		time.Sleep(apiPollInterval)
-		data, err = GetAPI(id)
+		data, err = fetcher.GetMeasurement(id)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -261,26 +266,26 @@ func OutputResults(id string, ctx model.Context) {
 		// Poll API until the measurement is complete
 		for data.Status == "in-progress" {
 			time.Sleep(apiPollInterval)
-			data, err = GetAPI(id)
+			data, err = fetcher.GetMeasurement(id)
 			if err != nil {
 				fmt.Println(err)
 				return
 			}
 		}
+		switch {
+		case ctx.CI:
+			OutputCI(id, data, ctx)
+			return
+		case ctx.JsonOutput:
+			OutputJson(id, fetcher)
+			return
+		case ctx.Latency:
+			OutputLatency(id, data, ctx)
+			return
+		default:
+			panic(fmt.Sprintf("case not handled. %+v", ctx))
+		}
 	}
 
-	switch {
-	case ctx.JsonOutput:
-		OutputJson(id)
-		return
-	case ctx.Latency:
-		OutputLatency(id, data, ctx)
-		return
-	case ctx.CI:
-		OutputCI(id, data, ctx)
-		return
-	default:
-		LiveView(id, data, ctx)
-		return
-	}
+	LiveView(id, data, ctx)
 }

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -1,4 +1,4 @@
-package client
+package view
 
 import (
 	"testing"


### PR DESCRIPTION
Based on https://github.com/jsdelivr/globalping/blob/master/docs/CLIENT_GUIDELINES.md
Fixes #33 

> Set the inProgressUpdates option to true if the application is running in interactive mode so that the user sees the results right away.
If the application is interactive by default but also implements a "CI" mode to be used in scripts, do not set the flag in the CI mode
- done in previous PR

> Use the following algorithm for measurement result pooling:
Request the measurement status.
If the status is in-progress, wait 1 second and repeat from step 1. Note that it is important to wait 1 second after receiving the response, instead of simply using an "every second interval". For large measurements, the request itself may take a few hundred milliseconds to complete.
If the status is anything else, stop. The measurement is no longer running.
- Implemented with 500 ms interval as it gives more real-time looking results

> Set a User-Agent header. The recommended format and approach is [as here](https://github.com/jsdelivr/data.jsdelivr.com/blob/60c5154d26c403ba9dd403a8ddc5e42a31931f0d/config/default.js#L9).
- Done (Format `globalping-cli/{Version} (https://github.com/jsdelivr/globalping-cli)`)

> Set an Accept-Encoding header with a value of either br (preferred) or gzip, depending on what your client can support. The compression has a significant impact on the response size.
- Implemented with `br`

> When requesting the measurement status, implement ETag-based client-side caching using the ETag/If-None-Match headers.
- Implemented