### PR TITLE
Install probe command

### DIFF
--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -34,7 +34,7 @@ func installProbeCmdRun(cmd *cobra.Command, args []string) {
 	dockerInspectCmd := exec.Command("docker", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
 	containerStatus, err := dockerInspectCmd.Output()
 	if err == nil {
-		fmt.Printf("The globalping-probe container is already installed on your system and is in the status: %s\n", containerStatus)
+		fmt.Printf("The globalping-probe container is already installed on your system. Current status: %s\n", containerStatus)
 		return
 	}
 

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -38,9 +38,9 @@ func installProbeCmdRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	ok := askUser("The globalping-probe container will now be pulled and run. Do you agree ?")
+	ok := askUser("The Globalping probe container will now be pulled and run. Do you agree ?")
 	if !ok {
-		fmt.Println("globalping-probe installation not confirmed, exiting ...")
+		fmt.Println("Globalping probe installation not confirmed, exiting ...")
 		return
 	}
 
@@ -52,6 +52,8 @@ func installProbeCmdRun(cmd *cobra.Command, args []string) {
 		fmt.Printf("docker info command failed: %v\n\n", err)
 		return
 	}
+
+	fmt.Printf("The Globalping probe has been installed successfully.\n")
 }
 
 func askUser(s string) bool {

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,7 +35,8 @@ func installProbeCmdRun(cmd *cobra.Command, args []string) {
 	dockerInspectCmd := exec.Command("docker", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
 	containerStatus, err := dockerInspectCmd.Output()
 	if err == nil {
-		fmt.Printf("The globalping-probe container is already installed on your system. Current status: %s\n", containerStatus)
+		containerStatusStr := string(bytes.TrimSpace(containerStatus))
+		fmt.Printf("The globalping-probe container is already installed on your system. Current status: %s\n", containerStatusStr)
 		return
 	}
 

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(installProbeCmd)
+}
+
+var installProbeCmd = &cobra.Command{
+	Use:   "install-probe",
+	Short: "Installs and runs the Globalping probe locally in a Docker container.",
+	Long: `Installs and runs the Globalping probe locally in a Docker container.
+This command pulls the globalping-probe container and runs it. It requires Docker to be installed.`,
+	Run: installProbeCmdRun,
+}
+
+func installProbeCmdRun(cmd *cobra.Command, args []string) {
+	dockerInfoCmd := exec.Command("docker", "info")
+	dockerInfoCmd.Stderr = os.Stderr
+	err := dockerInfoCmd.Run()
+	if err != nil {
+		fmt.Printf("docker info command failed: %v\n\n", err)
+		fmt.Println("Docker was not detected on your system. Docker is required to install the Globalping probe. Please install Docker and try again.")
+		return
+	}
+
+	dockerInspectCmd := exec.Command("docker", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
+	containerStatus, err := dockerInspectCmd.Output()
+	if err == nil {
+		fmt.Printf("The globalping-probe container is already installed on your system and is in the status: %s\n", containerStatus)
+		return
+	}
+
+	ok := askUser("The globalping-probe container will now be pulled and run. Do you agree ?")
+	if !ok {
+		fmt.Println("globalping-probe installation not confirmed, exiting ...")
+		return
+	}
+
+	dockerRunCmd := exec.Command("docker", "run", "-d", "--log-driver", "local", "--network", "host", "--restart", "always", "--name", "globalping-probe", "ghcr.io/jsdelivr/globalping-probe")
+	dockerRunCmd.Stdout = os.Stdout
+	dockerRunCmd.Stderr = os.Stderr
+	err = dockerRunCmd.Run()
+	if err != nil {
+		fmt.Printf("docker info command failed: %v\n\n", err)
+		return
+	}
+}
+
+func askUser(s string) bool {
+	fmt.Printf("%s [Y/n] ", s)
+
+	r := bufio.NewReader(os.Stdin)
+
+	c, _, err := r.ReadRune()
+	if err != nil {
+		fmt.Printf("failed to read character %v", err)
+		return false
+	}
+
+	switch c {
+	case 'Y':
+		return true
+	default:
+		return false
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,18 @@ module github.com/jsdelivr/globalping-cli
 go 1.20
 
 require (
+	github.com/andybalholm/brotli v1.0.5
 	github.com/charmbracelet/lipgloss v0.7.1
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.58
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 )
 
 require (
 	atomicgo.dev/cursor v0.1.1 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect
-	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -30,7 +31,6 @@ require (
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,7 +97,6 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
-golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Fixes #5 

- added install-probe command
  - checks if docker is installed locally
  - checks if the globalping-probe container already exists 
  - asks for user permission to install and run the globalping-probe container
  - installs and runs the globalping-probe container
- tested in Macos / Docker For Mac
- tested in Debian GNU/Linux 11 / docker.io
- tested in Windows 10 Pro / Docker For Windows
- podman not supported yet (created separate issue #51)
