### PR TITLE
Install probe podman

### DIFF
--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -50,6 +50,10 @@ Please confirm to pull and run our Docker container (ghcr.io/jsdelivr/globalping
 	}
 
 	fmt.Printf("The Globalping probe started successfully. Thank you for joining our community! \n")
+
+	if containerEngine == probe.ContainerEnginePodman {
+		fmt.Printf("When you using Podman, you also need to install a service to make sure the container starts on boot. Please see our instructions here: https://github.com/jsdelivr/globalping-probe/blob/master/README.md#podman-alternative\n")
+	}
 }
 
 func askUser(s string) bool {

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -51,7 +51,7 @@ func installProbeCmdRun(cmd *cobra.Command, args []string) {
 	fmt.Printf("The Globalping probe started successfully. Thank you for joining our community! \n")
 
 	if containerEngine == probe.ContainerEnginePodman {
-		fmt.Printf("When you using Podman, you also need to install a service to make sure the container starts on boot. Please see our instructions here: https://github.com/jsdelivr/globalping-probe/blob/master/README.md#podman-alternative\n")
+		fmt.Printf("When you are using Podman, you also need to install a service to make sure the container starts on boot. Please see our instructions here: https://github.com/jsdelivr/globalping-probe/blob/master/README.md#podman-alternative\n")
 	}
 }
 

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -36,8 +36,7 @@ func installProbeCmdRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	ok := askUser(`The Globalping platform is a community powered project and relies on individuals like yourself to host our probes and make them accessible to everyone else.
-Please confirm to pull and run our Docker container (ghcr.io/jsdelivr/globalping-probe)`)
+	ok := askUser(containerPullMessage(containerEngine))
 	if !ok {
 		fmt.Println("You can also run a probe manually, check our GitHub for detailed instructions. Exited without changes.")
 		return
@@ -54,6 +53,18 @@ Please confirm to pull and run our Docker container (ghcr.io/jsdelivr/globalping
 	if containerEngine == probe.ContainerEnginePodman {
 		fmt.Printf("When you using Podman, you also need to install a service to make sure the container starts on boot. Please see our instructions here: https://github.com/jsdelivr/globalping-probe/blob/master/README.md#podman-alternative\n")
 	}
+}
+
+func containerPullMessage(containerEngine probe.ContainerEngine) string {
+	pre := "The Globalping platform is a community powered project and relies on individuals like yourself to host our probes and make them accessible to everyone else.\n"
+	var mid string
+	post := "Please confirm to pull and run our Docker container (ghcr.io/jsdelivr/globalping-probe)"
+
+	if containerEngine == probe.ContainerEnginePodman {
+		mid = "We have detected that you are using podman, the 'sudo podman' command will be used to pull the container.\n"
+	}
+
+	return pre + mid + post
 }
 
 func askUser(s string) bool {

--- a/lib/probe/container_engine.go
+++ b/lib/probe/container_engine.go
@@ -1,0 +1,42 @@
+package probe
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type ContainerEngine string
+
+const (
+	ContainerEngineUnknown ContainerEngine = "Unknown"
+	ContainerEngineDocker  ContainerEngine = "Docker"
+	ContainerEnginePodman  ContainerEngine = "Podman"
+)
+
+func DetectContainerEngine() (ContainerEngine, error) {
+	// check if docker is installed
+	dockerInfoCmd := exec.Command("docker", "info")
+	dockerInfoCmd.Stderr = os.Stderr
+	dockerInfoErr := dockerInfoCmd.Run()
+	if dockerInfoErr == nil {
+		// check if docker is aliased to podman
+		aliasCmd := exec.Command("type", "docker")
+		aliasResults, _ := aliasCmd.Output()
+		if strings.Contains(string(aliasResults), "podman") {
+			return ContainerEnginePodman, nil
+		}
+
+		return ContainerEngineDocker, nil
+	}
+
+	// check if podman is installed
+	podmanInfoCmd := exec.Command("podman", "info")
+	podmanInfoCmd.Stderr = os.Stderr
+	podmanInfoErr := podmanInfoCmd.Run()
+	if podmanInfoErr == nil {
+		return ContainerEnginePodman, nil
+	}
+
+	return ContainerEngineUnknown, dockerInfoErr
+}

--- a/lib/probe/probe.go
+++ b/lib/probe/probe.go
@@ -38,7 +38,7 @@ func inspectContainerDocker() error {
 }
 
 func inspectContainerPodman() error {
-	cmd := exec.Command("podman", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
+	cmd := exec.Command("sudo", "podman", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
 	containerStatus, err := cmd.Output()
 	if err == nil {
 		containerStatusStr := string(bytes.TrimSpace(containerStatus))
@@ -85,7 +85,7 @@ func runContainerDocker() error {
 }
 
 func runContainerPodman() error {
-	cmd := exec.Command("podman", "run", "--cap-add=NET_RAW", "-d", "--network", "host", "--restart=always", "--name", "globalping-probe", "ghcr.io/jsdelivr/globalping-probe")
+	cmd := exec.Command("sudo", "podman", "run", "--cap-add=NET_RAW", "-d", "--network", "host", "--restart=always", "--name", "globalping-probe", "ghcr.io/jsdelivr/globalping-probe")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/lib/probe/probe.go
+++ b/lib/probe/probe.go
@@ -1,0 +1,92 @@
+package probe
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func InspectContainer(containerEngine ContainerEngine) error {
+	switch containerEngine {
+	case ContainerEngineDocker:
+		err := inspectContainerDocker()
+		if err != nil {
+			return err
+		}
+	case ContainerEnginePodman:
+		err := inspectContainerPodman()
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("Unknown container engine %s", containerEngine)
+	}
+
+	return nil
+}
+
+func inspectContainerDocker() error {
+	cmd := exec.Command("docker", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
+	containerStatus, err := cmd.Output()
+	if err == nil {
+		containerStatusStr := string(bytes.TrimSpace(containerStatus))
+		return fmt.Errorf("The globalping-probe container is already installed on your system. Current status: %s", containerStatusStr)
+	}
+
+	return nil
+}
+
+func inspectContainerPodman() error {
+	cmd := exec.Command("podman", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
+	containerStatus, err := cmd.Output()
+	if err == nil {
+		containerStatusStr := string(bytes.TrimSpace(containerStatus))
+		return fmt.Errorf("The globalping-probe container is already installed on your system. Current status: %s", containerStatusStr)
+	}
+
+	return nil
+}
+
+func RunContainer(containerEngine ContainerEngine) error {
+	switch containerEngine {
+	case ContainerEngineDocker:
+		err := runContainerDocker()
+		if err != nil {
+			return err
+		}
+	case ContainerEnginePodman:
+		err := runContainerPodman()
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("Unknown container engine %s", containerEngine)
+	}
+
+	return nil
+}
+
+func runContainerDocker() error {
+	cmd := exec.Command("docker", "run", "-d", "--log-driver", "local", "--network", "host", "--restart", "always", "--name", "globalping-probe", "ghcr.io/jsdelivr/globalping-probe")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to run container: %v", err)
+	}
+
+	return nil
+}
+
+func runContainerPodman() error {
+	cmd := exec.Command("podman", "run", "--cap-add=NET_RAW", "-d", "--network", "host", "--restart=always", "--name", "globalping-probe", "ghcr.io/jsdelivr/globalping-probe")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to run container: %v", err)
+	}
+
+	return nil
+}

--- a/lib/probe/probe.go
+++ b/lib/probe/probe.go
@@ -42,6 +42,11 @@ func inspectContainerPodman() error {
 	containerStatus, err := cmd.Output()
 	if err == nil {
 		containerStatusStr := string(bytes.TrimSpace(containerStatus))
+		if containerStatusStr == "" {
+			// false positive as podmain keeps container info after deletion
+			return nil
+		}
+
 		return fmt.Errorf("The globalping-probe container is already installed on your system. Current status: %s", containerStatusStr)
 	}
 


### PR DESCRIPTION
Fixes #51 

- Adds Podman support to the install-probe command

- Tested on Debian Linux 11

- Detects podman installation, even when aliased to "docker"

- I've added info about the need to install a service to run podman container on boot, as mentioned here https://github.com/jsdelivr/globalping-probe/blob/master/README.md#podman-alternative

- I've used the podman command from the globalping-probe repo README `podman run --cap-add=NET_RAW -d --network host --restart=always --name globalping-probe ghcr.io/jsdelivr/globalping-probe
`, but when inspecting the podman logs I see this error:

```[2023-04-24 10:27:57] [INFO] [682] [general] Start probe version 0.20.0 in a production mode
[2023-04-24 10:27:58] [DEBUG] [682] [general] connection to API established
[2023-04-24 10:27:58] [INFO] [682] [api:connect] connected from (Council Bluffs, US, NA) (lat: 41.2324 long: -95.8751)
[2023-04-24 10:27:58] [WARN] [682] [status-manager] ping test promise rejected: Command failed with exit code 2: unbuffer ping -4 -c 6 -i 0.2 -w 15 l.root-servers.net
ping: socket: Operation not permitted
{
  shortMessage: 'Command failed with exit code 2: unbuffer ping -4 -c 6 -i 0.2 -w 15 l.root-servers.net',
  command: 'unbuffer ping -4 -c 6 -i 0.2 -w 15 l.root-servers.net',
  escapedCommand: 'unbuffer ping -4 -c 6 -i 0.2 -w 15 l.root-servers.net',
  exitCode: 2,
  signal: undefined,
  signalDescription: undefined,
  stdout: 'ping: socket: Operation not permitted',
  stderr: '',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}```
