### PR TITLE
Improve http output

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -75,7 +75,7 @@ Using the dig format @resolver. For example:
 			return nil
 		}
 
-		view.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx, opts)
 		return nil
 	},
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -142,7 +142,7 @@ func httpCmdRun(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	view.OutputResults(res.ID, ctx)
+	view.OutputResults(res.ID, ctx, m)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func buildHttpMeasurementRequest() (model.PostMeasurement, error) {
 			Query:   overrideOpt(urlData.Query, httpCmdOpts.Query),
 			Host:    overrideOpt(urlData.Host, httpCmdOpts.Host),
 			Headers: headers,
-			Method:  httpCmdOpts.Method,
+			Method:  strings.ToUpper(httpCmdOpts.Method),
 		},
 		Resolver: overrideOpt(ctx.Resolver, httpCmdOpts.Resolver),
 	}
@@ -185,10 +185,10 @@ func buildHttpMeasurementRequest() (model.PostMeasurement, error) {
 	return m, nil
 }
 
-func parseHttpHeaders(rawHeaders []string) (map[string]string, error) {
+func parseHttpHeaders(headerStrings []string) (map[string]string, error) {
 	h := map[string]string{}
 
-	for _, r := range rawHeaders {
+	for _, r := range headerStrings {
 		k, v, ok := strings.Cut(r, ": ")
 		if !ok {
 			return nil, fmt.Errorf("invalid header: %s", r)

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -104,6 +104,9 @@ Examples:
   # HTTP GET request to google.com from 2 probes from London or Belgium in CI mode
   http google.com from London,Belgium --limit 2 --method get --ci
 
+  # HTTP GET request to google.com from a probe in London. Returns the full output
+  http google.com from London --method get --full
+
   # HTTP HEAD request to jsdelivr.com from a probe that is from the AWS network and is located in Montreal using HTTP2. 2 http headers are added to the request.
   http jsdelivr.com from aws+montreal --protocol http2 --header "Accept-Encoding: br,gzip" -H "Accept-Language: *"
 
@@ -164,6 +167,12 @@ func buildHttpMeasurementRequest() (model.PostMeasurement, error) {
 		return m, err
 	}
 
+	method := strings.ToUpper(httpCmdOpts.Method)
+	if ctx.Full {
+		// override method to GET
+		method = "GET"
+	}
+
 	m.Target = urlData.Host
 	m.Locations = createLocations(ctx.From)
 	m.Limit = ctx.Limit
@@ -177,7 +186,7 @@ func buildHttpMeasurementRequest() (model.PostMeasurement, error) {
 			Query:   overrideOpt(urlData.Query, httpCmdOpts.Query),
 			Host:    overrideOpt(urlData.Host, httpCmdOpts.Host),
 			Headers: headers,
-			Method:  strings.ToUpper(httpCmdOpts.Method),
+			Method:  method,
 		},
 		Resolver: overrideOpt(ctx.Resolver, httpCmdOpts.Resolver),
 	}
@@ -226,4 +235,5 @@ func init() {
 	httpCmd.Flags().IntVar(&httpCmdOpts.Port, "port", 0, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
 	httpCmd.Flags().StringVar(&httpCmdOpts.Resolver, "resolver", "", "Specifies the resolver server used for DNS lookup (default is defined by the probe's network)")
 	httpCmd.Flags().StringArrayVarP(&httpCmdOpts.Headers, "header", "H", nil, "Specifies a HTTP header to be added to the request, in the format \"Key: Value\". Multiple headers can be added by adding multiple flags")
+	httpCmd.Flags().BoolVar(&ctx.Full, "full", false, "Full output. Uses an HTTP GET request, and outputs the status, headers and body to the output")
 }

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -44,35 +44,35 @@ func TestOverrideOpt(t *testing.T) {
 }
 
 func TestParseHttpHeaders_None(t *testing.T) {
-	rawHeaders := []string{}
+	headerStrings := []string{}
 
-	m, err := parseHttpHeaders(rawHeaders)
+	m, err := parseHttpHeaders(headerStrings)
 	assert.NoError(t, err)
 
 	assert.Nil(t, nil, m)
 }
 
 func TestParseHttpHeaders_Single(t *testing.T) {
-	rawHeaders := []string{"ABC: 123x"}
+	headerStrings := []string{"ABC: 123x"}
 
-	m, err := parseHttpHeaders(rawHeaders)
+	m, err := parseHttpHeaders(headerStrings)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]string{"ABC": "123x"}, m)
 }
 
 func TestParseHttpHeaders_Multiple(t *testing.T) {
-	rawHeaders := []string{"ABC: 123x", "DEF: 456y,789z"}
+	headerStrings := []string{"ABC: 123x", "DEF: 456y,789z"}
 
-	m, err := parseHttpHeaders(rawHeaders)
+	m, err := parseHttpHeaders(headerStrings)
 	assert.NoError(t, err)
 
 	assert.Equal(t, map[string]string{"ABC": "123x", "DEF": "456y,789z"}, m)
 }
 
 func TestParseHttpHeaders_Invalid(t *testing.T) {
-	rawHeaders := []string{"ABC=123x"}
+	headerStrings := []string{"ABC=123x"}
 
-	_, err := parseHttpHeaders(rawHeaders)
+	_, err := parseHttpHeaders(headerStrings)
 	assert.ErrorContains(t, err, "invalid header")
 }

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/jsdelivr/globalping-cli/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,4 +76,81 @@ func TestParseHttpHeaders_Invalid(t *testing.T) {
 
 	_, err := parseHttpHeaders(headerStrings)
 	assert.ErrorContains(t, err, "invalid header")
+}
+
+func TestBuildHttpMeasurementRequest_FULL(t *testing.T) {
+	ctx = model.Context{
+		Target: "https://example.com/my/path?x=123&yz=abc",
+		From:   "london",
+		Full:   true,
+	}
+
+	httpCmdOpts = &HttpCmdOpts{
+		Method: "HEAD",
+	}
+
+	m, err := buildHttpMeasurementRequest()
+	assert.NoError(t, err)
+
+	expectedM := model.PostMeasurement{Limit: 0,
+		Locations: []model.Locations{
+			{Magic: "london"}},
+		Type:              "http",
+		Target:            "example.com",
+		InProgressUpdates: true,
+		Options: &model.MeasurementOptions{
+			Protocol: "https",
+			Request: &model.RequestOptions{
+				Headers: map[string]string{},
+				Path:    "/my/path",
+				Host:    "example.com",
+				Query:   "x=123&yz=abc",
+				Method:  "GET",
+			},
+		},
+	}
+
+	assert.Equal(t, expectedM, m)
+
+	// restore
+	httpCmdOpts = &HttpCmdOpts{}
+	ctx = model.Context{}
+}
+
+func TestBuildHttpMeasurementRequest_HEAD(t *testing.T) {
+	ctx = model.Context{
+		Target: "https://example.com/my/path?x=123&yz=abc",
+		From:   "london",
+	}
+
+	httpCmdOpts = &HttpCmdOpts{
+		Method: "HEAD",
+	}
+
+	m, err := buildHttpMeasurementRequest()
+	assert.NoError(t, err)
+
+	expectedM := model.PostMeasurement{Limit: 0,
+		Locations: []model.Locations{
+			{Magic: "london"}},
+		Type:              "http",
+		Target:            "example.com",
+		InProgressUpdates: true,
+		Options: &model.MeasurementOptions{
+			Protocol: "https",
+			Request: &model.RequestOptions{
+				Headers: map[string]string{},
+				Path:    "/my/path",
+				Host:    "example.com",
+				Query:   "x=123&yz=abc",
+				Method:  "HEAD",
+			},
+		},
+	}
+
+	assert.Equal(t, expectedM, m)
+
+	// restore
+	httpCmdOpts = &HttpCmdOpts{}
+	ctx = model.Context{}
 }

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -62,7 +62,7 @@ Examples:
 			return nil
 		}
 
-		view.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx, opts)
 		return nil
 	},
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -56,7 +56,7 @@ Examples:
 			return nil
 		}
 
-		view.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx, opts)
 		return nil
 	},
 }

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -64,7 +64,7 @@ Examples:
 			return nil
 		}
 
-		view.OutputResults(res.ID, ctx)
+		view.OutputResults(res.ID, ctx, opts)
 		return nil
 	},
 }

--- a/model/get.go
+++ b/model/get.go
@@ -18,6 +18,8 @@ type ProbeData struct {
 type ResultData struct {
 	Status           string                 `json:"status"`
 	RawOutput        string                 `json:"rawOutput"`
+	RawHeaders       string                 `json:"rawHeaders"`
+	RawBody          string                 `json:"rawBody"`
 	ResolvedAddress  string                 `json:"resolvedAddress"`
 	ResolvedHostname string                 `json:"resolvedHostname"`
 	Stats            map[string]interface{} `json:"stats,omitempty"`

--- a/model/root.go
+++ b/model/root.go
@@ -13,4 +13,6 @@ type Context struct {
 	Latency bool
 	// CI flag is used to determine whether the output should be in a format that is easy to parse by a CI tool
 	CI bool
+	// Full output
+	Full bool
 }

--- a/view/view.go
+++ b/view/view.go
@@ -234,14 +234,17 @@ func PrintStandardResults(data *model.GetMeasurement, ctx model.Context, m model
 	for i, result := range data.Results {
 		if i > 0 {
 			// new line as separator if more than 1 result
-			fmt.Fprintln(os.Stderr)
+			fmt.Println()
 		}
 
 		// Output slightly different format if state is available
 		fmt.Fprintln(os.Stderr, generateHeader(result, ctx))
 
 		if ctx.Cmd == "http" && m.Options != nil && m.Options.Request != nil && m.Options.Request.Method == "GET" {
-			fmt.Fprintln(os.Stderr, strings.TrimSpace(result.Result.RawHeaders))
+			if ctx.Full {
+				fmt.Println(strings.TrimSpace(result.Result.RawHeaders))
+				fmt.Println()
+			}
 			fmt.Println(strings.TrimSpace(result.Result.RawBody))
 		} else {
 			fmt.Println(strings.TrimSpace(result.Result.RawOutput))

--- a/view/view.go
+++ b/view/view.go
@@ -78,7 +78,7 @@ func generateHeader(result model.MeasurementResponse, ctx model.Context) string 
 
 var apiPollInterval = 500 * time.Millisecond
 
-func LiveView(id string, data *model.GetMeasurement, ctx model.Context) {
+func LiveView(id string, data *model.GetMeasurement, ctx model.Context, m model.PostMeasurement) {
 	var err error
 
 	// Create new writer
@@ -137,8 +137,7 @@ func LiveView(id string, data *model.GetMeasurement, ctx model.Context) {
 		fmt.Printf("failed to stop writer: %v\n", err)
 	}
 
-	// Print full output
-	fmt.Println(strings.TrimSpace(output.String()))
+	PrintStandardResults(data, ctx, m)
 }
 
 // If json flag is used, only output json
@@ -227,7 +226,11 @@ func OutputLatency(id string, data *model.GetMeasurement, ctx model.Context) {
 }
 
 func OutputCI(data *model.GetMeasurement, ctx model.Context, m model.PostMeasurement) {
-	// Output every result in case of multiple probes
+	PrintStandardResults(data, ctx, m)
+}
+
+// Prints non-json non-latency results to the screen
+func PrintStandardResults(data *model.GetMeasurement, ctx model.Context, m model.PostMeasurement) {
 	for i, result := range data.Results {
 		if i > 0 {
 			// new line as separator if more than 1 result
@@ -291,5 +294,5 @@ func OutputResults(id string, ctx model.Context, m model.PostMeasurement) {
 		}
 	}
 
-	LiveView(id, data, ctx)
+	LiveView(id, data, ctx, m)
 }

--- a/view/view.go
+++ b/view/view.go
@@ -240,16 +240,16 @@ func PrintStandardResults(data *model.GetMeasurement, ctx model.Context, m model
 		// Output slightly different format if state is available
 		fmt.Fprintln(os.Stderr, generateHeader(result, ctx))
 
-		if ctx.Cmd == "http" && m.Options != nil && m.Options.Request != nil && m.Options.Request.Method == "GET" {
-			if ctx.Full {
-				fmt.Println(strings.TrimSpace(result.Result.RawHeaders))
-				fmt.Println()
-			}
+		if isBodyOnlyHttpGet(ctx, m) {
 			fmt.Println(strings.TrimSpace(result.Result.RawBody))
 		} else {
 			fmt.Println(strings.TrimSpace(result.Result.RawOutput))
 		}
 	}
+}
+
+func isBodyOnlyHttpGet(ctx model.Context, m model.PostMeasurement) bool {
+	return ctx.Cmd == "http" && m.Options != nil && m.Options.Request != nil && m.Options.Request.Method == "GET" && !ctx.Full
 }
 
 func OutputResults(id string, ctx model.Context, m model.PostMeasurement) {

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -42,7 +42,7 @@ func TestHeadersTags(t *testing.T) {
 	assert.Equal(t, "> Continent, Country, (State), City, ASN:12345, Network (tag2)", generateHeader(newResult, testContext))
 }
 
-func TestOutputCIHTTPGet(t *testing.T) {
+func TestPrintStandardResultsHTTPGet(t *testing.T) {
 	osStdErr := os.Stderr
 	osStdOut := os.Stdout
 
@@ -110,7 +110,7 @@ func TestOutputCIHTTPGet(t *testing.T) {
 		},
 	}
 
-	OutputCI(data, ctx, m)
+	PrintStandardResults(data, ctx, m)
 	myStdOut.Close()
 	myStdErr.Close()
 
@@ -123,7 +123,7 @@ func TestOutputCIHTTPGet(t *testing.T) {
 	assert.Equal(t, "Body 1\nBody 2\n", string(outContent))
 }
 
-func TestOutputCIHTTPHead(t *testing.T) {
+func TestPrintStandardResultsHTTPHead(t *testing.T) {
 	osStdErr := os.Stderr
 	osStdOut := os.Stdout
 
@@ -189,7 +189,7 @@ func TestOutputCIHTTPHead(t *testing.T) {
 		},
 	}
 
-	OutputCI(data, ctx, m)
+	PrintStandardResults(data, ctx, m)
 	myStdOut.Close()
 	myStdErr.Close()
 
@@ -202,7 +202,7 @@ func TestOutputCIHTTPHead(t *testing.T) {
 	assert.Equal(t, "Headers 1\nHeaders 2\n", string(outContent))
 }
 
-func TestOutputCIPing(t *testing.T) {
+func TestPrintStandardResultsPing(t *testing.T) {
 	osStdErr := os.Stderr
 	osStdOut := os.Stdout
 
@@ -260,7 +260,7 @@ func TestOutputCIPing(t *testing.T) {
 		},
 	}
 
-	OutputCI(data, ctx, m)
+	PrintStandardResults(data, ctx, m)
 	myStdOut.Close()
 	myStdErr.Close()
 

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -116,11 +116,11 @@ func TestPrintStandardResultsHTTPGet(t *testing.T) {
 
 	errContent, err := io.ReadAll(rStdErr)
 	assert.NoError(t, err)
-	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\nHeaders 1\n\n> NA, US, (NY), New York, ASN:567, Network 2\nHeaders 2\n", string(errContent))
+	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\n> NA, US, (NY), New York, ASN:567, Network 2\n", string(errContent))
 
 	outContent, err := io.ReadAll(rStdOut)
 	assert.NoError(t, err)
-	assert.Equal(t, "Body 1\nBody 2\n", string(outContent))
+	assert.Equal(t, "Body 1\n\nBody 2\n", string(outContent))
 }
 
 func TestPrintStandardResultsHTTPHead(t *testing.T) {
@@ -195,11 +195,11 @@ func TestPrintStandardResultsHTTPHead(t *testing.T) {
 
 	errContent, err := io.ReadAll(rStdErr)
 	assert.NoError(t, err)
-	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\n\n> NA, US, (NY), New York, ASN:567, Network 2\n", string(errContent))
+	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\n> NA, US, (NY), New York, ASN:567, Network 2\n", string(errContent))
 
 	outContent, err := io.ReadAll(rStdOut)
 	assert.NoError(t, err)
-	assert.Equal(t, "Headers 1\nHeaders 2\n", string(outContent))
+	assert.Equal(t, "Headers 1\n\nHeaders 2\n", string(outContent))
 }
 
 func TestPrintStandardResultsPing(t *testing.T) {
@@ -266,9 +266,9 @@ func TestPrintStandardResultsPing(t *testing.T) {
 
 	errContent, err := io.ReadAll(rStdErr)
 	assert.NoError(t, err)
-	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\n\n> NA, US, (NY), New York, ASN:567, Network 2\n", string(errContent))
+	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\n> NA, US, (NY), New York, ASN:567, Network 2\n", string(errContent))
 
 	outContent, err := io.ReadAll(rStdOut)
 	assert.NoError(t, err)
-	assert.Equal(t, "Ping Results 1\nPing Results 2\n", string(outContent))
+	assert.Equal(t, "Ping Results 1\n\nPing Results 2\n", string(outContent))
 }

--- a/view/view_test.go
+++ b/view/view_test.go
@@ -123,6 +123,88 @@ func TestPrintStandardResultsHTTPGet(t *testing.T) {
 	assert.Equal(t, "Body 1\n\nBody 2\n", string(outContent))
 }
 
+func TestPrintStandardResultsHTTPGetFull(t *testing.T) {
+	osStdErr := os.Stderr
+	osStdOut := os.Stdout
+
+	rStdErr, myStdErr, err := os.Pipe()
+	assert.NoError(t, err)
+	defer rStdErr.Close()
+
+	rStdOut, myStdOut, err := os.Pipe()
+	assert.NoError(t, err)
+	defer rStdOut.Close()
+
+	os.Stderr = myStdErr
+	os.Stdout = myStdOut
+
+	defer func() {
+		os.Stderr = osStdErr
+		os.Stdout = osStdOut
+	}()
+
+	ctx := model.Context{
+		Cmd:  "http",
+		CI:   true,
+		Full: true,
+	}
+
+	m := model.PostMeasurement{
+		Options: &model.MeasurementOptions{
+			Request: &model.RequestOptions{
+				Method: "GET",
+			},
+		},
+	}
+
+	data := &model.GetMeasurement{
+		Results: []model.MeasurementResponse{
+			{
+				Probe: model.ProbeData{
+					Continent: "EU",
+					Country:   "DE",
+					City:      "Berlin",
+					ASN:       123,
+					Network:   "Network 1",
+				},
+				Result: model.ResultData{
+					RawOutput:  "Headers 1\nBody 1",
+					RawHeaders: "Headers 1",
+					RawBody:    "Body 1",
+				},
+			},
+
+			{
+				Probe: model.ProbeData{
+					Continent: "NA",
+					Country:   "US",
+					City:      "New York",
+					State:     "NY",
+					ASN:       567,
+					Network:   "Network 2",
+				},
+				Result: model.ResultData{
+					RawOutput:  "Headers 2\nBody 2",
+					RawHeaders: "Headers 2",
+					RawBody:    "Body 2",
+				},
+			},
+		},
+	}
+
+	PrintStandardResults(data, ctx, m)
+	myStdOut.Close()
+	myStdErr.Close()
+
+	errContent, err := io.ReadAll(rStdErr)
+	assert.NoError(t, err)
+	assert.Equal(t, "> EU, DE, Berlin, ASN:123, Network 1\n> NA, US, (NY), New York, ASN:567, Network 2\n", string(errContent))
+
+	outContent, err := io.ReadAll(rStdOut)
+	assert.NoError(t, err)
+	assert.Equal(t, "Headers 1\nBody 1\n\nHeaders 2\nBody 2\n", string(outContent))
+}
+
 func TestPrintStandardResultsHTTPHead(t *testing.T) {
 	osStdErr := os.Stderr
 	osStdOut := os.Stdout


### PR DESCRIPTION
Fixes #55 
For http GET requests:
- print rawHeaders to stderr
- print rawBody to stdout