### PR TITLE
Update goreleaser to 1.17.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.16.2
+          version: v1.17.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN_GORELEASER }}
           CHOCOLATEY_APIKEY: ${{ secrets.CHOCOLATEY_APIKEY }}
-          
+
       - run: echo ("VERSION_NAME=" + $env:GITHUB_REF_NAME.TrimStart("v")) >> $env:GITHUB_ENV
       - run: echo $VERSION_NAME
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.17.2
+          version: v1.19.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN_GORELEASER }}


### PR DESCRIPTION
Part of https://github.com/jsdelivr/globalping-cli/issues/49

- built and installed .deb file on Debian 11 without any issues
- build and installed .rpm file on CentOS Linux release 7.9.2009 without any issues