### PR TITLE
update goreleaser to v1.20.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.19.2
+          version: v1.20.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN_GORELEASER }}


### PR DESCRIPTION
Update to latest goreleaser version that fixes .deb and .rpm packages built from windows machines. 
Tested on my fork of the repo, produces correct .deb and .rpm packages.
Closes #49 