### PR TITLE
feat: history command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,12 @@ Measurement Commands:
 Additional Commands:
   completion    Generate the autocompletion script for the specified shell
   help          Help about any command
+  history       Show the history of your measurements
   install-probe Join the community powered Globalping platform by running a Docker container.
   version       Print the version number of Globalping CLI
 
 Flags:
-  -C, --ci            Disable realtime terminal updates and color suitable for CI and scripting (default false)
-  -F, --from string   Comma-separated list of location values to match against or a measurement ID
-                      For example, the partial or full name of a continent, region (e.g eastern europe), country, US state, city or network
-                      Or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements. (default "world")
   -h, --help          help for globalping
-  -J, --json          Output results in JSON format (default false)
-      --latency       Output only the stats of a measurement (default false). Only applies to the dns, http and ping commands
-  -L, --limit int     Limit the number of probes to use (default 1)
 
 Use "globalping [command] --help" for more information about a command.
 ```
@@ -305,6 +299,24 @@ Vienna, AT, EU, EDIS GmbH (AS57169)                    |   22 |   0.00% |  0.47 
 Stockholm, SE, EU, The Constant Company, LLC (AS20473) |   22 |   0.00% |  1.03 ms |  0.83 ms |  1.15 ms |  4.66 ms
 Madrid, ES, EU, EDGOO NETWORKS LLC (AS47787)           |   22 |   0.00% |  0.24 ms |  0.13 ms |  0.26 ms |  0.42 ms
 ^C
+```
+
+#### History
+
+You can view the history of your measurements by running the `history` command.
+
+```bash
+globalping history
+1 | 2024-03-22 16:20:30 | ping google.com from last
+> https://www.jsdelivr.com/globalping?measurement=gdS0v9h5eTIxKEOk
+2 | 2024-03-22 16:09:10 | traceroute google.com from New York --limit 2
+> https://www.jsdelivr.com/globalping?measurement=P4ZA7IcX04K359XN
+3 | 2024-03-22 16:08:44 | mtr google.com from New York --limit 2
+> https://www.jsdelivr.com/globalping?measurement=ePITYQJZhg9yn8NE
+4 | 2024-03-22 16:08:19 | http google.com from London,Belgium --limit 2 --method get --ci
+> https://www.jsdelivr.com/globalping?measurement=Sq8OEuRYNs6s147G
+5 | 2024-03-22 16:07:45 | dns google.com from New York --limit 2
+> https://www.jsdelivr.com/globalping?measurement=OMFclzhYExXTFJDV
 ```
 
 #### Learn about available flags

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Measurement Commands:
 Additional Commands:
   completion    Generate the autocompletion script for the specified shell
   help          Help about any command
-  history       Show the history of your measurements
+  history       Show the history of your measurements in your current session
   install-probe Join the community powered Globalping platform by running a Docker container.
   version       Print the version number of Globalping CLI
 
@@ -314,16 +314,16 @@ You can view the history of your measurements by running the `history` command.
 
 ```bash
 globalping history
-1 | 2024-03-22 16:20:30 | ping google.com from last
-> https://www.jsdelivr.com/globalping?measurement=gdS0v9h5eTIxKEOk
-2 | 2024-03-22 16:09:10 | traceroute google.com from New York --limit 2
-> https://www.jsdelivr.com/globalping?measurement=P4ZA7IcX04K359XN
-3 | 2024-03-22 16:08:44 | mtr google.com from New York --limit 2
-> https://www.jsdelivr.com/globalping?measurement=ePITYQJZhg9yn8NE
-4 | 2024-03-22 16:08:19 | http google.com from London,Belgium --limit 2 --method get --ci
-> https://www.jsdelivr.com/globalping?measurement=Sq8OEuRYNs6s147G
-5 | 2024-03-22 16:07:45 | dns google.com from New York --limit 2
-> https://www.jsdelivr.com/globalping?measurement=OMFclzhYExXTFJDV
+1 | 2024-03-27 11:56:46 | ping google.com
+> https://www.jsdelivr.com/globalping?measurement=itcR65tYCqbouXib
+- | 2024-03-27 11:57:01 | dns google.com from last
+> https://www.jsdelivr.com/globalping?measurement=kWc5UBK9A6G4RUYM
+2 | 2024-03-27 11:57:20 | traceroute google.com from New York --limit 2
+> https://www.jsdelivr.com/globalping?measurement=Yz7A1UifUonZsC3C
+3 | 2024-03-27 11:57:37 | mtr google.com from New York --limit 2
+> https://www.jsdelivr.com/globalping?measurement=SX1NBgfDKiabM1vZ
+4 | 2024-03-27 11:57:52 | http google.com from London,Belgium --limit 2 --method get --ci
+> https://www.jsdelivr.com/globalping?measurement=eclwFSYX0zgU10Cs
 ```
 
 #### Learn about available flags

--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ Additional Commands:
   version       Print the version number of Globalping CLI
 
 Flags:
+  -C, --ci            Disable realtime terminal updates and color suitable for CI and scripting (default false)
+  -F, --from string   Comma-separated list of location values to match against or a measurement ID
+                      For example, the partial or full name of a continent, region (e.g eastern europe), country, US state, city or network
+                      Or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements. (default "world")
   -h, --help          help for globalping
+  -J, --json          Output results in JSON format (default false)
+      --latency       Output only the stats of a measurement (default false). Only applies to the dns, http and ping commands
+  -L, --limit int     Limit the number of probes to use (default 1)
 
 Use "globalping [command] --help" for more information about a command.
 ```

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -82,6 +82,7 @@ func (r *Root) getLocations() ([]globalping.Locations, error) {
 		if mId == "" {
 			mId = strings.TrimSpace(fromArr[0])
 		} else {
+			r.ctx.IsLocationFromSession = true
 			r.ctx.RecordToSession = false
 		}
 		return []globalping.Locations{{Magic: mId}}, nil

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -23,7 +23,7 @@ func Test_UpdateContext(t *testing.T) {
 }
 
 func test_updateContext_NoArg(t *testing.T) {
-	ctx := &view.Context{}
+	ctx := createDefaultContext("ping")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 
@@ -35,7 +35,7 @@ func test_updateContext_NoArg(t *testing.T) {
 }
 
 func test_updateContext_Country(t *testing.T) {
-	ctx := &view.Context{}
+	ctx := createDefaultContext("ping")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 
@@ -48,7 +48,7 @@ func test_updateContext_Country(t *testing.T) {
 
 // Check if country with whitespace is parsed correctly
 func test_updateContext_CountryWhitespace(t *testing.T) {
-	ctx := &view.Context{}
+	ctx := createDefaultContext("ping")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 
@@ -60,7 +60,7 @@ func test_updateContext_CountryWhitespace(t *testing.T) {
 }
 
 func test_updateContext_NoTarget(t *testing.T) {
-	ctx := &view.Context{}
+	ctx := createDefaultContext("ping")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 
@@ -73,7 +73,7 @@ func test_uodateContext_CIEnv(t *testing.T) {
 	t.Setenv("CI", "true")
 	defer t.Setenv("CI", oldCI)
 
-	ctx := &view.Context{}
+	ctx := createDefaultContext("ping")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -53,11 +54,17 @@ Using the dig format @resolver. For example:
 
 	// dns specific flags
 	flags := dnsCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", "", "Specifies the protocol to use for the DNS query (TCP or UDP) (default \"udp\")")
-	flags.IntVar(&r.ctx.Port, "port", 0, "Send the query to a non-standard port on the server (default 53)")
-	flags.StringVar(&r.ctx.Resolver, "resolver", "", "Resolver is the hostname or IP address of the name server to use (default empty)")
-	flags.StringVar(&r.ctx.QueryType, "type", "", "Specifies the type of DNS query to perform (default \"A\")")
-	flags.BoolVar(&r.ctx.Trace, "trace", false, "Toggle tracing of the delegation path from the root name servers (default false)")
+	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
+	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
+	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
+	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
+	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
+	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol to use for the DNS query (TCP or UDP) (default \"udp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Send the query to a non-standard port on the server (default 53)")
+	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Resolver is the hostname or IP address of the name server to use (default empty)")
+	flags.StringVar(&r.ctx.QueryType, "type", r.ctx.QueryType, "Specifies the type of DNS query to perform (default \"A\")")
+	flags.BoolVar(&r.ctx.Trace, "trace", r.ctx.Trace, "Toggle tracing of the delegation path from the root name servers (default false)")
 
 	r.Cmd.AddCommand(dnsCmd)
 }
@@ -100,7 +107,12 @@ func (r *Root) RunDNS(cmd *cobra.Command, args []string) error {
 	}
 
 	r.ctx.MeasurementsCreated++
-
+	hm := &view.HistoryItem{
+		Id:        res.ID,
+		Status:    globalping.StatusInProgress,
+		StartedAt: r.time.Now(),
+	}
+	r.ctx.History.Push(hm)
 	if r.ctx.RecordToSession {
 		r.ctx.RecordToSession = false
 		err := saveIdToSession(res.ID)

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -69,6 +69,7 @@ func (r *Root) RunDNS(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	defer r.UpdateHistory()
 	r.ctx.RecordToSession = true
 
 	opts := &globalping.MeasurementCreate{

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -54,12 +54,6 @@ Using the dig format @resolver. For example:
 
 	// dns specific flags
 	flags := dnsCmd.Flags()
-	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
-	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
-	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
-	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
-	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
-	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
 	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol to use for the DNS query (TCP or UDP) (default \"udp\")")
 	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Send the query to a non-standard port on the server (default 53)")
 	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Resolver is the hostname or IP address of the name server to use (default empty)")

--- a/cmd/dns_test.go
+++ b/cmd/dns_test.go
@@ -37,10 +37,13 @@ func Test_Execute_DNS_Default(t *testing.T) {
 	viewerMock := mocks.NewMockViewer(ctrl)
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
+	timeMock := mocks.NewMockTime(ctrl)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
 	ctx := createDefaultContext("dns")
-	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
+	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 
 	os.Args = []string{"globalping", "dns", "jsdelivr.com",
 		"from", "Berlin",

--- a/cmd/dns_test.go
+++ b/cmd/dns_test.go
@@ -39,7 +39,7 @@ func Test_Execute_DNS_Default(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("dns")
 	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
 
 	os.Args = []string{"globalping", "dns", "jsdelivr.com",

--- a/cmd/dns_test.go
+++ b/cmd/dns_test.go
@@ -38,7 +38,7 @@ func Test_Execute_DNS_Default(t *testing.T) {
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -70,6 +70,14 @@ func Test_Execute_DNS_Default(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1,
+		"dns jsdelivr.com from Berlin --limit 2 --type MX --resolver 1.1.1.1 --port 99 --protocol tcp --trace",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }

--- a/cmd/dns_test.go
+++ b/cmd/dns_test.go
@@ -76,6 +76,7 @@ func Test_Execute_DNS_Default(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1,
 		"dns jsdelivr.com from Berlin --limit 2 --type MX --resolver 1.1.1.1 --port 99 --protocol tcp --trace",
 	)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -37,29 +37,29 @@ func (r *Root) initHistory() {
 		Short: "Show the history of your measurements in your current session",
 		Long: `Show the history of your measurements in your current session
 Examples:
-  # Show the first measurements
+  # Show all the measurements
   history
 
-  # Show the last 10 measurements
-  history --last 10
-  
   # Show the first 5 measurements
-  history --first 5`,
+  history --head 5
+
+  # Show the last 10 measurements
+  history --tail 10`,
 	}
 
 	flags := historyCmd.Flags()
-	flags.UintVar(&r.ctx.First, "first", r.ctx.First, "Number of first measurements to show")
-	flags.UintVar(&r.ctx.Last, "last", r.ctx.Last, "Number of last measurements to show")
+	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "Number of first measurements to show")
+	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "Number of last measurements to show")
 
 	r.Cmd.AddCommand(historyCmd)
 }
 
 func (r *Root) RunHistory(cmd *cobra.Command, args []string) {
-	var limit int = 5 // default to last 5
-	if r.ctx.First > 0 {
-		limit = int(r.ctx.First)
-	} else if r.ctx.Last > 0 {
-		limit = -int(r.ctx.Last)
+	var limit int = 0
+	if r.ctx.Head > 0 {
+		limit = int(r.ctx.Head)
+	} else if r.ctx.Tail > 0 {
+		limit = -int(r.ctx.Tail)
 	}
 	items, err := r.GetHistory(limit)
 	if err != nil {
@@ -123,7 +123,7 @@ func (r *Root) GetHistory(limit int) ([]string, error) {
 		return nil, ErrReadHistory
 	}
 	defer f.Close()
-	// Read from the start of the file
+	// Read from the end of the file
 	if limit < 0 {
 		fStats, err := f.Stat()
 		if err != nil {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -48,8 +48,8 @@ Examples:
 	}
 
 	flags := historyCmd.Flags()
-	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "Number of first measurements to show")
-	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "Number of last measurements to show")
+	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "Number of measurements to show from the beginning of the history")
+	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "Number of measurements to show from the end of the history")
 
 	r.Cmd.AddCommand(historyCmd)
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -17,24 +17,27 @@ import (
 )
 
 var (
-	readHistoryErr        = "failed to read history: %s"
+	ErrReadHistory = errors.New("failed to read history")
+)
+
+var (
 	invalidHistoryItemErr = "invalid history item: %s"
 	saveToHistoryErr      = "failed to save to history: %s"
 )
 
 const (
-	// <version>|<time>|<id>|<command>
-	HistoryItemVersion1 int = 1
+	// <version>|<index>|<time>|<id>|<command>
+	HistoryItemVersion1 string = "1"
 )
 
 func (r *Root) initHistory() {
 	historyCmd := &cobra.Command{
 		Run:   r.RunHistory,
 		Use:   "history",
-		Short: "Show the history of your measurements",
-		Long: `Show the history of your measurements
+		Short: "Show the history of your measurements in your current session",
+		Long: `Show the history of your measurements in your current session
 Examples:
-  # Show the last measurements
+  # Show the first measurements
   history
 
   # Show the last 10 measurements
@@ -54,9 +57,9 @@ Examples:
 func (r *Root) RunHistory(cmd *cobra.Command, args []string) {
 	var limit int = 5 // default to last 5
 	if r.ctx.First > 0 {
-		limit = -int(r.ctx.First)
+		limit = int(r.ctx.First)
 	} else if r.ctx.Last > 0 {
-		limit = int(r.ctx.Last)
+		limit = -int(r.ctx.Last)
 	}
 	items, err := r.GetHistory(limit)
 	if err != nil {
@@ -64,7 +67,7 @@ func (r *Root) RunHistory(cmd *cobra.Command, args []string) {
 		return
 	}
 	if len(items) == 0 {
-		r.printer.Println("No history found")
+		r.printer.Println("No history items found")
 		return
 	}
 	for _, item := range items {
@@ -88,14 +91,22 @@ func (r *Root) UpdateHistory() error {
 			return fmt.Errorf(saveToHistoryErr, err)
 		}
 	}
+	index := "-"
+	if !r.ctx.IsLocationFromSession {
+		i, err := getIndex()
+		if err != nil {
+			return err
+		}
+		index = fmt.Sprintf("%d", i)
+	}
+	time := r.time.Now().Unix()
+	cmd := strings.Join(os.Args[1:], " ")
 	f, err := os.OpenFile(getHistoryPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf(saveToHistoryErr, err)
 	}
 	defer f.Close()
-	time := r.time.Now().Unix()
-	cmd := strings.Join(os.Args[1:], " ")
-	_, err = f.WriteString(fmt.Sprintf("%d|%d|%s|%s\n", HistoryItemVersion1, time, ids, cmd))
+	_, err = f.WriteString(fmt.Sprintf("%s|%s|%d|%s|%s\n", HistoryItemVersion1, index, time, ids, cmd))
 	if err != nil {
 		return fmt.Errorf(saveToHistoryErr, err)
 	}
@@ -103,18 +114,35 @@ func (r *Root) UpdateHistory() error {
 }
 
 func (r *Root) GetHistory(limit int) ([]string, error) {
+	items := make([]string, 0)
 	f, err := os.Open(getHistoryPath())
 	if err != nil {
-		return nil, fmt.Errorf(readHistoryErr, err)
+		if errors.Is(err, fs.ErrNotExist) {
+			return items, nil
+		}
+		return nil, ErrReadHistory
 	}
 	defer f.Close()
-	items := make([]string, 0)
 	// Read from the start of the file
 	if limit < 0 {
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
+		fStats, err := f.Stat()
+		if err != nil {
+			return nil, ErrReadHistory
+		}
+		if fStats.Size() == 0 {
+			return items, nil
+		}
+		scanner := backscanner.New(f, int(fStats.Size()-1)) // -1 to skip last newline
+		for {
 			limit++
-			item, err := parseHistoryItem(scanner.Text(), len(items))
+			b, _, err := scanner.LineBytes()
+			if err != nil {
+				if err == io.EOF {
+					return items, nil
+				}
+				return nil, ErrReadHistory
+			}
+			item, err := parseHistoryItem(string(b))
 			if err != nil {
 				return nil, err
 			}
@@ -125,24 +153,10 @@ func (r *Root) GetHistory(limit int) ([]string, error) {
 		}
 		return items, nil
 	}
-	fStats, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf(readHistoryErr, err)
-	}
-	if fStats.Size() == 0 {
-		return items, nil
-	}
-	scanner := backscanner.New(f, int(fStats.Size()-1)) // -1 to skip last newline
-	for {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
 		limit--
-		b, _, err := scanner.LineBytes()
-		if err != nil {
-			if err == io.EOF {
-				return items, nil
-			}
-			return nil, fmt.Errorf(readHistoryErr, err)
-		}
-		item, err := parseHistoryItem(string(b), len(items))
+		item, err := parseHistoryItem(scanner.Text())
 		if err != nil {
 			return nil, err
 		}
@@ -154,32 +168,79 @@ func (r *Root) GetHistory(limit int) ([]string, error) {
 	return items, nil
 }
 
-func parseHistoryItem(line string, index int) (string, error) {
-	parts := strings.Split(line, "|")
-	if len(parts) < 1 {
-		return "", fmt.Errorf(invalidHistoryItemErr, line)
-	}
-	version, err := strconv.Atoi(parts[0])
+func parseHistoryItem(line string) (string, error) {
+	parts, err := getHistoryItem(line)
 	if err != nil {
-		return "", fmt.Errorf(invalidHistoryItemErr, line)
+		return "", err
 	}
-	switch version {
-	case HistoryItemVersion1:
-		if len(parts) != 4 {
-			return "", fmt.Errorf(invalidHistoryItemErr, line)
-		}
-		t, err := strconv.ParseInt(parts[1], 10, 64)
+	if parts[0] == HistoryItemVersion1 {
+		t, err := strconv.ParseInt(parts[2], 10, 64)
 		if err != nil {
 			return "", fmt.Errorf(invalidHistoryItemErr, line)
 		}
 		return fmt.Sprintf(
-			"%d | %s | %s\n%s",
-			index+1,
+			"%s | %s | %s\n%s",
+			parts[1],
 			time.Unix(t, 0).Format("2006-01-02 15:04:05"),
-			parts[3],
-			"> "+view.ShareURL+parts[2],
+			parts[4],
+			"> "+view.ShareURL+parts[3],
 		), nil
+	}
+	return "", nil
+}
+
+func getHistoryItem(line string) ([]string, error) {
+	parts := strings.Split(line, "|")
+	if len(parts) < 1 {
+		return nil, fmt.Errorf(invalidHistoryItemErr, line)
+	}
+	switch parts[0] {
+	case HistoryItemVersion1:
+		if len(parts) != 5 {
+			return nil, fmt.Errorf(invalidHistoryItemErr, line)
+		}
+		return parts, nil
 	default:
-		return "", fmt.Errorf("invalid history item version: %d", version)
+		return nil, fmt.Errorf(invalidHistoryItemErr, line)
+	}
+}
+
+func getIndex() (int, error) {
+	f, err := os.Open(getHistoryPath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 1, nil
+		}
+		return 0, ErrReadHistory
+	}
+	defer f.Close()
+	fStats, err := f.Stat()
+	if err != nil {
+		return 0, ErrReadHistory
+	}
+	if fStats.Size() == 0 {
+		return 1, nil
+	}
+	scanner := backscanner.New(f, int(fStats.Size()-1)) // -1 to skip last newline
+	for {
+		b, _, err := scanner.LineBytes()
+		if err != nil {
+			if err == io.EOF {
+				return 1, nil
+			}
+			return 0, ErrReadHistory
+		}
+		parts, err := getHistoryItem(string(b))
+		if err != nil {
+			return 0, err
+		}
+		if parts[1] == "-" {
+			continue
+		}
+		index, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, err
+		}
+		return index + 1, nil
 	}
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/icza/backscanner"
+	"github.com/jsdelivr/globalping-cli/view"
+	"github.com/spf13/cobra"
+)
+
+var (
+	readHistoryErr        = "failed to read history: %s"
+	invalidHistoryItemErr = "invalid history item: %s"
+	saveToHistoryErr      = "failed to save to history: %s"
+)
+
+const (
+	// <version>|<time>|<id>|<command>
+	HistoryItemVersion1 int = 1
+)
+
+func (r *Root) initHistory() {
+	historyCmd := &cobra.Command{
+		Run:   r.RunHistory,
+		Use:   "history",
+		Short: "Show the history of your measurements",
+		Long: `Show the history of your measurements
+Examples:
+  # Show the last measurements
+  history
+
+  # Show the last 10 measurements
+  history --last 10
+  
+  # Show the first 5 measurements
+  history --first 5`,
+	}
+
+	flags := historyCmd.Flags()
+	flags.UintVar(&r.ctx.First, "first", r.ctx.First, "Number of first measurements to show")
+	flags.UintVar(&r.ctx.Last, "last", r.ctx.Last, "Number of last measurements to show")
+
+	r.Cmd.AddCommand(historyCmd)
+}
+
+func (r *Root) RunHistory(cmd *cobra.Command, args []string) {
+	var limit int = 5 // default to last 5
+	if r.ctx.First > 0 {
+		limit = -int(r.ctx.First)
+	} else if r.ctx.Last > 0 {
+		limit = int(r.ctx.Last)
+	}
+	items, err := r.GetHistory(limit)
+	if err != nil {
+		r.printer.Println(err)
+		return
+	}
+	if len(items) == 0 {
+		r.printer.Println("No history found")
+		return
+	}
+	for _, item := range items {
+		r.printer.Println(item)
+	}
+}
+
+func (r *Root) UpdateHistory() error {
+	ids := r.ctx.History.ToString("+")
+	if ids == "" {
+		return nil
+	}
+	_, err := os.Stat(getSessionPath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			err := os.Mkdir(getSessionPath(), 0755)
+			if err != nil {
+				return fmt.Errorf(saveToHistoryErr, err)
+			}
+		} else {
+			return fmt.Errorf(saveToHistoryErr, err)
+		}
+	}
+	f, err := os.OpenFile(getHistoryPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf(saveToHistoryErr, err)
+	}
+	defer f.Close()
+	time := r.time.Now().Unix()
+	cmd := strings.Join(os.Args[1:], " ")
+	_, err = f.WriteString(fmt.Sprintf("%d|%d|%s|%s\n", HistoryItemVersion1, time, ids, cmd))
+	if err != nil {
+		return fmt.Errorf(saveToHistoryErr, err)
+	}
+	return nil
+}
+
+func (r *Root) GetHistory(limit int) ([]string, error) {
+	f, err := os.Open(getHistoryPath())
+	if err != nil {
+		return nil, fmt.Errorf(readHistoryErr, err)
+	}
+	defer f.Close()
+	items := make([]string, 0)
+	// Read from the start of the file
+	if limit < 0 {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			limit++
+			item, err := parseHistoryItem(scanner.Text(), len(items))
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+			if limit == 0 {
+				break
+			}
+		}
+		return items, nil
+	}
+	fStats, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf(readHistoryErr, err)
+	}
+	if fStats.Size() == 0 {
+		return items, nil
+	}
+	scanner := backscanner.New(f, int(fStats.Size()-1)) // -1 to skip last newline
+	for {
+		limit--
+		b, _, err := scanner.LineBytes()
+		if err != nil {
+			if err == io.EOF {
+				return items, nil
+			}
+			return nil, fmt.Errorf(readHistoryErr, err)
+		}
+		item, err := parseHistoryItem(string(b), len(items))
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		if limit == 0 {
+			break
+		}
+	}
+	return items, nil
+}
+
+func parseHistoryItem(line string, index int) (string, error) {
+	parts := strings.Split(line, "|")
+	if len(parts) < 1 {
+		return "", fmt.Errorf(invalidHistoryItemErr, line)
+	}
+	version, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", fmt.Errorf(invalidHistoryItemErr, line)
+	}
+	switch version {
+	case HistoryItemVersion1:
+		if len(parts) != 4 {
+			return "", fmt.Errorf(invalidHistoryItemErr, line)
+		}
+		t, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return "", fmt.Errorf(invalidHistoryItemErr, line)
+		}
+		return fmt.Sprintf(
+			"%d | %s | %s\n%s",
+			index+1,
+			time.Unix(t, 0).Format("2006-01-02 15:04:05"),
+			parts[3],
+			"> "+view.ShareURL+parts[2],
+		), nil
+	default:
+		return "", fmt.Errorf("invalid history item version: %d", version)
+	}
+}

--- a/cmd/history_test.go
+++ b/cmd/history_test.go
@@ -67,11 +67,12 @@ func Test_Execute_History_Default(t *testing.T) {
 			createDefaultExpectedHistoryItem("-", timeStr, "ping jsdelivr.com from last", measurementID2)+
 			createDefaultExpectedHistoryItem("2", timeStr, "ping jsdelivr.com", measurementID2)+
 			createDefaultExpectedHistoryItem("3", timeStr, "ping jsdelivr.com", measurementID2)+
-			createDefaultExpectedHistoryItem("4", timeStr, "ping jsdelivr.com", measurementID2),
+			createDefaultExpectedHistoryItem("4", timeStr, "ping jsdelivr.com", measurementID2)+
+			createDefaultExpectedHistoryItem("5", timeStr, "ping jsdelivr.com", measurementID3),
 		w.String())
 
 	w.Reset()
-	os.Args = []string{"globalping", "history", "--last", "2"}
+	os.Args = []string{"globalping", "history", "--tail", "2"}
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t,
@@ -80,7 +81,7 @@ func Test_Execute_History_Default(t *testing.T) {
 		w.String())
 
 	w.Reset()
-	os.Args = []string{"globalping", "history", "--first", "2"}
+	os.Args = []string{"globalping", "history", "--head", "2"}
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t,

--- a/cmd/history_test.go
+++ b/cmd/history_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/mocks"
+	"github.com/jsdelivr/globalping-cli/view"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_Execute_History_Default(t *testing.T) {
+	t.Cleanup(sessionCleanup)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	timeMock := mocks.NewMockTime(ctrl)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
+
+	ctx := createDefaultContext("ping")
+	w := new(bytes.Buffer)
+	printer := view.NewPrinter(nil, w, w)
+	root := NewRoot(printer, ctx, nil, timeMock, nil, nil)
+	os.Args = []string{"globalping", "ping", "jsdelivr.com"}
+
+	ctx.History.Push(&view.HistoryItem{
+		Id:        measurementID1,
+		Status:    globalping.StatusInProgress,
+		StartedAt: defaultCurrentTime,
+	})
+	root.UpdateHistory()
+	ctx.History.Push(&view.HistoryItem{
+		Id:        measurementID2,
+		Status:    globalping.StatusInProgress,
+		StartedAt: defaultCurrentTime,
+	})
+	root.UpdateHistory()
+	root.UpdateHistory()
+	root.UpdateHistory()
+	root.UpdateHistory()
+	ctx.History.Push(&view.HistoryItem{
+		Id:        measurementID3,
+		Status:    globalping.StatusInProgress,
+		StartedAt: defaultCurrentTime,
+	})
+	root.UpdateHistory()
+
+	os.Args = []string{"globalping", "history"}
+	err := root.Cmd.ExecuteContext(context.TODO())
+	assert.NoError(t, err)
+
+	timeStr := time.Unix(defaultCurrentTime.Unix(), 0).Format("2006-01-02 15:04:05")
+	assert.Equal(t,
+		createDefaultExpectedHistoryItem(1, timeStr, measurementID3)+
+			createDefaultExpectedHistoryItem(2, timeStr, measurementID2)+
+			createDefaultExpectedHistoryItem(3, timeStr, measurementID2)+
+			createDefaultExpectedHistoryItem(4, timeStr, measurementID2)+
+			createDefaultExpectedHistoryItem(5, timeStr, measurementID2),
+		w.String())
+
+	w.Reset()
+	os.Args = []string{"globalping", "history", "--last", "2"}
+	err = root.Cmd.ExecuteContext(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t,
+		createDefaultExpectedHistoryItem(1, timeStr, measurementID3)+
+			createDefaultExpectedHistoryItem(2, timeStr, measurementID2),
+		w.String())
+
+	w.Reset()
+	os.Args = []string{"globalping", "history", "--first", "2"}
+	err = root.Cmd.ExecuteContext(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t,
+		createDefaultExpectedHistoryItem(1, timeStr, measurementID1)+
+			createDefaultExpectedHistoryItem(2, timeStr, measurementID2),
+		w.String())
+}

--- a/cmd/history_test.go
+++ b/cmd/history_test.go
@@ -35,12 +35,18 @@ func Test_Execute_History_Default(t *testing.T) {
 		StartedAt: defaultCurrentTime,
 	})
 	root.UpdateHistory()
+
+	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "last"}
+	ctx.IsLocationFromSession = true
 	ctx.History.Push(&view.HistoryItem{
 		Id:        measurementID2,
 		Status:    globalping.StatusInProgress,
 		StartedAt: defaultCurrentTime,
 	})
 	root.UpdateHistory()
+
+	os.Args = []string{"globalping", "ping", "jsdelivr.com"}
+	ctx.IsLocationFromSession = false
 	root.UpdateHistory()
 	root.UpdateHistory()
 	root.UpdateHistory()
@@ -57,11 +63,11 @@ func Test_Execute_History_Default(t *testing.T) {
 
 	timeStr := time.Unix(defaultCurrentTime.Unix(), 0).Format("2006-01-02 15:04:05")
 	assert.Equal(t,
-		createDefaultExpectedHistoryItem(1, timeStr, measurementID3)+
-			createDefaultExpectedHistoryItem(2, timeStr, measurementID2)+
-			createDefaultExpectedHistoryItem(3, timeStr, measurementID2)+
-			createDefaultExpectedHistoryItem(4, timeStr, measurementID2)+
-			createDefaultExpectedHistoryItem(5, timeStr, measurementID2),
+		createDefaultExpectedHistoryItem("1", timeStr, "ping jsdelivr.com", measurementID1)+
+			createDefaultExpectedHistoryItem("-", timeStr, "ping jsdelivr.com from last", measurementID2)+
+			createDefaultExpectedHistoryItem("2", timeStr, "ping jsdelivr.com", measurementID2)+
+			createDefaultExpectedHistoryItem("3", timeStr, "ping jsdelivr.com", measurementID2)+
+			createDefaultExpectedHistoryItem("4", timeStr, "ping jsdelivr.com", measurementID2),
 		w.String())
 
 	w.Reset()
@@ -69,8 +75,8 @@ func Test_Execute_History_Default(t *testing.T) {
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t,
-		createDefaultExpectedHistoryItem(1, timeStr, measurementID3)+
-			createDefaultExpectedHistoryItem(2, timeStr, measurementID2),
+		createDefaultExpectedHistoryItem("5", timeStr, "ping jsdelivr.com", measurementID3)+
+			createDefaultExpectedHistoryItem("4", timeStr, "ping jsdelivr.com", measurementID2),
 		w.String())
 
 	w.Reset()
@@ -78,7 +84,7 @@ func Test_Execute_History_Default(t *testing.T) {
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t,
-		createDefaultExpectedHistoryItem(1, timeStr, measurementID1)+
-			createDefaultExpectedHistoryItem(2, timeStr, measurementID2),
+		createDefaultExpectedHistoryItem("1", timeStr, "ping jsdelivr.com", measurementID1)+
+			createDefaultExpectedHistoryItem("-", timeStr, "ping jsdelivr.com from last", measurementID2),
 		w.String())
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -69,12 +69,6 @@ Examples:
 
 	// http specific flags
 	flags := httpCmd.Flags()
-	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
-	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
-	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
-	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
-	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
-	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
 	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the query protocol (HTTP, HTTPS, HTTP2) (default \"HTTP\")")
 	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
 	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specifies the resolver server used for DNS lookup (default is defined by the probe's network)")

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -68,15 +69,21 @@ Examples:
 
 	// http specific flags
 	flags := httpCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", "", "Specifies the query protocol (HTTP, HTTPS, HTTP2) (default \"HTTP\")")
-	flags.IntVar(&r.ctx.Port, "port", 0, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
-	flags.StringVar(&r.ctx.Resolver, "resolver", "", "Specifies the resolver server used for DNS lookup (default is defined by the probe's network)")
-	flags.StringVar(&r.ctx.Host, "host", "", "Specifies the Host header, which is going to be added to the request (default host defined in target)")
-	flags.StringVar(&r.ctx.Path, "path", "", "A URL pathname (default \"/\")")
-	flags.StringVar(&r.ctx.Query, "query", "", "A query-string")
-	flags.StringVar(&r.ctx.Method, "method", "", "Specifies the HTTP method to use (HEAD or GET) (default \"HEAD\")")
-	flags.StringArrayVarP(&r.ctx.Headers, "header", "H", nil, "Specifies a HTTP header to be added to the request, in the format \"Key: Value\". Multiple headers can be added by adding multiple flags")
-	flags.BoolVar(&r.ctx.Full, "full", false, "Full output. Uses an HTTP GET request, and outputs the status, headers and body to the output")
+	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
+	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
+	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
+	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
+	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
+	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the query protocol (HTTP, HTTPS, HTTP2) (default \"HTTP\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
+	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specifies the resolver server used for DNS lookup (default is defined by the probe's network)")
+	flags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "Specifies the Host header, which is going to be added to the request (default host defined in target)")
+	flags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "A URL pathname (default \"/\")")
+	flags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "A query-string")
+	flags.StringVar(&r.ctx.Method, "method", r.ctx.Method, "Specifies the HTTP method to use (HEAD or GET) (default \"HEAD\")")
+	flags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "Specifies a HTTP header to be added to the request, in the format \"Key: Value\". Multiple headers can be added by adding multiple flags")
+	flags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "Full output. Uses an HTTP GET request, and outputs the status, headers and body to the output")
 
 	r.Cmd.AddCommand(httpCmd)
 }
@@ -109,7 +116,12 @@ func (r *Root) RunHTTP(cmd *cobra.Command, args []string) error {
 	}
 
 	r.ctx.MeasurementsCreated++
-
+	hm := &view.HistoryItem{
+		Id:        res.ID,
+		Status:    globalping.StatusInProgress,
+		StartedAt: r.time.Now(),
+	}
+	r.ctx.History.Push(hm)
 	if r.ctx.RecordToSession {
 		r.ctx.RecordToSession = false
 		err := saveIdToSession(res.ID)

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -88,6 +88,7 @@ func (r *Root) RunHTTP(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	defer r.UpdateHistory()
 	r.ctx.RecordToSession = true
 
 	opts, err := r.buildHttpMeasurementRequest()

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -84,6 +84,7 @@ func Test_Execute_HTTP_Default(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1,
 		"http jsdelivr.com from Berlin --protocol HTTPS --method GET --host example.com --path /robots.txt --query test=1 --header X-Test: 1 --resolver 1.1.1.1 --port 99 --full",
 	)

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -41,7 +41,7 @@ func Test_Execute_HTTP_Default(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("http")
 	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
 	os.Args = []string{"globalping", "http", "jsdelivr.com",
 		"from", "Berlin",
@@ -151,7 +151,7 @@ func Test_ParseHttpHeaders_Invalid(t *testing.T) {
 }
 
 func Test_BuildHttpMeasurementRequest_Full(t *testing.T) {
-	ctx := &view.Context{}
+	ctx := createDefaultContext("http")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 
@@ -184,7 +184,7 @@ func Test_BuildHttpMeasurementRequest_Full(t *testing.T) {
 }
 
 func Test_BuildHttpMeasurementRequest_HEAD(t *testing.T) {
-	ctx := &view.Context{}
+	ctx := createDefaultContext("http")
 	printer := view.NewPrinter(nil, nil, nil)
 	root := NewRoot(printer, ctx, nil, nil, nil, nil)
 

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -39,10 +39,13 @@ func Test_Execute_HTTP_Default(t *testing.T) {
 	viewerMock := mocks.NewMockViewer(ctrl)
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
+	timeMock := mocks.NewMockTime(ctrl)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
 	ctx := createDefaultContext("http")
-	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
+	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "http", "jsdelivr.com",
 		"from", "Berlin",
 		"--protocol", "HTTPS",

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -40,7 +40,7 @@ func Test_Execute_HTTP_Default(t *testing.T) {
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -78,8 +78,16 @@ func Test_Execute_HTTP_Default(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1,
+		"http jsdelivr.com from Berlin --protocol HTTPS --method GET --host example.com --path /robots.txt --query test=1 --header X-Test: 1 --resolver 1.1.1.1 --port 99 --full",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }
 
 func Test_ParseUrlData(t *testing.T) {

--- a/cmd/install_probe_test.go
+++ b/cmd/install_probe_test.go
@@ -27,7 +27,7 @@ func Test_Execute_Install_Probe_Docker(t *testing.T) {
 	reader := bytes.NewReader([]byte("Y\n"))
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(reader, w, w)
-	ctx := &view.Context{}
+	ctx := createDefaultContext("install-probe")
 	root := NewRoot(printer, ctx, nil, nil, nil, probeMock)
 	os.Args = []string{"globalping", "install-probe"}
 	err := root.Cmd.ExecuteContext(context.TODO())
@@ -41,8 +41,9 @@ Please confirm to pull and run our Docker container (ghcr.io/jsdelivr/globalping
 `, w.String())
 
 	expectedCtx := &view.Context{
-		From:  "world",
-		Limit: 1,
+		History: view.NewHistoryBuffer(1),
+		From:    "world",
+		Limit:   1,
 	}
 	assert.Equal(t, expectedCtx, ctx)
 }

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -44,11 +44,6 @@ Examples:
 
 	// mtr specific flags
 	flags := mtrCmd.Flags()
-	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
-	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
-	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
-	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
-	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
 	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol used (ICMP, TCP or UDP) (default \"icmp\")")
 	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use. Only applicable for TCP protocol (default 53)")
 	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specifies the number of packets to send to each hop (default 3)")

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -61,6 +61,7 @@ func (r *Root) RunMTR(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("the latency flag is not supported by the mtr command")
 	}
 
+	defer r.UpdateHistory()
 	r.ctx.RecordToSession = true
 
 	opts := &globalping.MeasurementCreate{

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -43,9 +44,14 @@ Examples:
 
 	// mtr specific flags
 	flags := mtrCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", "", "Specifies the protocol used (ICMP, TCP or UDP) (default \"icmp\")")
-	flags.IntVar(&r.ctx.Port, "port", 0, "Specifies the port to use. Only applicable for TCP protocol (default 53)")
-	flags.IntVar(&r.ctx.Packets, "packets", 0, "Specifies the number of packets to send to each hop (default 3)")
+	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
+	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
+	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
+	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
+	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol used (ICMP, TCP or UDP) (default \"icmp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use. Only applicable for TCP protocol (default 53)")
+	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specifies the number of packets to send to each hop (default 3)")
 
 	r.Cmd.AddCommand(mtrCmd)
 }
@@ -88,7 +94,12 @@ func (r *Root) RunMTR(cmd *cobra.Command, args []string) error {
 	}
 
 	r.ctx.MeasurementsCreated++
-
+	hm := &view.HistoryItem{
+		Id:        res.ID,
+		Status:    globalping.StatusInProgress,
+		StartedAt: r.time.Now(),
+	}
+	r.ctx.History.Push(hm)
 	if r.ctx.RecordToSession {
 		r.ctx.RecordToSession = false
 		err := saveIdToSession(res.ID)

--- a/cmd/mtr_test.go
+++ b/cmd/mtr_test.go
@@ -33,7 +33,7 @@ func Test_Execute_MTR_Default(t *testing.T) {
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -61,6 +61,14 @@ func Test_Execute_MTR_Default(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1,
+		"mtr jsdelivr.com from Berlin --limit 2 --protocol tcp --port 99 --packets 16",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }

--- a/cmd/mtr_test.go
+++ b/cmd/mtr_test.go
@@ -67,6 +67,7 @@ func Test_Execute_MTR_Default(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1,
 		"mtr jsdelivr.com from Berlin --limit 2 --protocol tcp --port 99 --packets 16",
 	)

--- a/cmd/mtr_test.go
+++ b/cmd/mtr_test.go
@@ -34,7 +34,7 @@ func Test_Execute_MTR_Default(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("mtr")
 	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
 	os.Args = []string{"globalping", "mtr", "jsdelivr.com",
 		"from", "Berlin",

--- a/cmd/mtr_test.go
+++ b/cmd/mtr_test.go
@@ -32,10 +32,13 @@ func Test_Execute_MTR_Default(t *testing.T) {
 	viewerMock := mocks.NewMockViewer(ctrl)
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
+	timeMock := mocks.NewMockTime(ctrl)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
 	ctx := createDefaultContext("mtr")
-	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
+	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "mtr", "jsdelivr.com",
 		"from", "Berlin",
 		"--limit", "2",

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -49,8 +49,14 @@ Examples:
 
 	// ping specific flags
 	flags := pingCmd.Flags()
-	flags.IntVar(&r.ctx.Packets, "packets", 0, "Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)")
-	flags.BoolVar(&r.ctx.Infinite, "infinite", false, "Keep pinging the target continuously until stopped (default false)")
+	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
+	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
+	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
+	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
+	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
+	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
+	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)")
+	flags.BoolVar(&r.ctx.Infinite, "infinite", r.ctx.Infinite, "Keep pinging the target continuously until stopped (default false)")
 
 	r.Cmd.AddCommand(pingCmd)
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -61,6 +61,7 @@ func (r *Root) RunPing(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	defer r.UpdateHistory()
 	r.ctx.RecordToSession = true
 	if r.ctx.Infinite {
 		r.ctx.Packets = 16

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -49,12 +49,6 @@ Examples:
 
 	// ping specific flags
 	flags := pingCmd.Flags()
-	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
-	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
-	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
-	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
-	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
-	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
 	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)")
 	flags.BoolVar(&r.ctx.Infinite, "infinite", r.ctx.Infinite, "Keep pinging the target continuously until stopped (default false)")
 

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -58,6 +58,7 @@ func Test_Execute_Ping_Default(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1,
 		"ping jsdelivr.com",
 	)
@@ -106,6 +107,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "@-1"
+	expectedCtx.IsLocationFromSession = true
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
@@ -138,6 +140,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "world"
 	expectedCtx.History.Slice[0].Id = measurementID2
+	expectedCtx.IsLocationFromSession = false
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
@@ -148,6 +151,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "@1"
+	expectedCtx.IsLocationFromSession = true
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
@@ -170,6 +174,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "world"
 	expectedCtx.History.Slice[0].Id = measurementID3
+	expectedCtx.IsLocationFromSession = false
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
@@ -181,6 +186,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "@2"
 	expectedCtx.RecordToSession = false
+	expectedCtx.IsLocationFromSession = true
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
@@ -207,6 +213,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Error(t, err, ErrIndexOutOfRange)
 
 	expectedCtx.From = "@-4"
+	expectedCtx.IsLocationFromSession = false
 	expectedCtx.RecordToSession = true
 	expectedCtx.MeasurementsCreated = 0
 	expectedCtx.History = view.NewHistoryBuffer(1)
@@ -409,6 +416,7 @@ func Test_Execute_Ping_Infinite(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1+"+"+measurementID2+"+"+measurementID3+"+"+measurementID4,
 		"ping jsdelivr.com --infinite from Berlin",
 	)
@@ -463,6 +471,7 @@ func Test_Execute_Ping_Infinite_Output_Error(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1,
 		"ping jsdelivr.com --infinite from Berlin",
 	)

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -33,7 +33,7 @@ func Test_Execute_Ping_Default(t *testing.T) {
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Return(defaultCurrentTime)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -52,8 +52,16 @@ func Test_Execute_Ping_Default(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1,
+		"ping jsdelivr.com",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }
 
 func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
@@ -76,7 +84,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	viewerMock.EXPECT().Output(measurementID3, expectedOpts).Times(3).Return(nil).After(c2)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Times(totalCalls).Return(defaultCurrentTime)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -395,8 +403,16 @@ func Test_Execute_Ping_Infinite(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1+"+"+measurementID2+"+"+measurementID3+"+"+measurementID4,
+		"ping jsdelivr.com --infinite from Berlin",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }
 
 func Test_Execute_Ping_Infinite_Output_Error(t *testing.T) {
@@ -421,7 +437,7 @@ func Test_Execute_Ping_Infinite_Output_Error(t *testing.T) {
 	viewerMock.EXPECT().OutputSummary().Times(0)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Return(defaultCurrentTime)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -441,6 +457,14 @@ func Test_Execute_Ping_Infinite_Output_Error(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1,
+		"ping jsdelivr.com --infinite from Berlin",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -37,7 +37,7 @@ func Test_Execute_Ping_Default(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("ping")
 	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 
 	os.Args = []string{"globalping", "ping", "jsdelivr.com"}
@@ -80,7 +80,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("ping")
 	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "Berlin,New York "}
 	err := root.Cmd.ExecuteContext(context.TODO())
@@ -90,6 +90,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	expectedCtx.From = "Berlin,New York"
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@-1"}
@@ -97,9 +98,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "@-1"
-	expectedCtx.MeasurementsCreated = 2
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "last"}
@@ -107,9 +108,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "last"
-	expectedCtx.MeasurementsCreated = 3
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "previous"}
@@ -117,9 +118,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "previous"
-	expectedCtx.MeasurementsCreated = 4
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: "world"}}
 	expectedResponse.ID = measurementID2
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
@@ -129,9 +130,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "world"
 	expectedCtx.History.Slice[0].Id = measurementID2
-	expectedCtx.MeasurementsCreated = 5
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@1"}
@@ -139,9 +140,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "@1"
-	expectedCtx.MeasurementsCreated = 6
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "first"}
@@ -149,9 +150,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "first"
-	expectedCtx.MeasurementsCreated = 7
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: "world"}}
 	expectedResponse.ID = measurementID3
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
@@ -161,9 +162,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "world"
 	expectedCtx.History.Slice[0].Id = measurementID3
-	expectedCtx.MeasurementsCreated = 8
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID2}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@2"}
@@ -172,9 +173,9 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "@2"
 	expectedCtx.RecordToSession = false
-	expectedCtx.MeasurementsCreated = 9
 	assert.Equal(t, expectedCtx, ctx)
 
+	ctx = createDefaultContext("ping")
 	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@-3"}
@@ -182,7 +183,6 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx.From = "@-3"
-	expectedCtx.MeasurementsCreated = 10
 	assert.Equal(t, expectedCtx, ctx)
 
 	assert.Equal(t, "", w.String())
@@ -192,6 +192,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	expectedHistory := []byte(measurementID1 + "\n" + measurementID2 + "\n" + measurementID3 + "\n")
 	assert.Equal(t, expectedHistory, b)
 
+	ctx = createDefaultContext("ping")
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@-4"}
 	err = root.Cmd.ExecuteContext(context.TODO())
@@ -199,52 +200,54 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 
 	expectedCtx.From = "@-4"
 	expectedCtx.RecordToSession = true
+	expectedCtx.MeasurementsCreated = 0
+	expectedCtx.History = view.NewHistoryBuffer(1)
 	assert.Equal(t, expectedCtx, ctx)
 	assert.Equal(t, "Error: index out of range\n", w.String())
 
 	sessionCleanup()
 
 	w.Reset()
+	ctx = createDefaultContext("ping")
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@1"}
 	err = root.Cmd.ExecuteContext(context.TODO())
-	assert.Error(t, err, ErrorNoPreviousMeasurements)
+	assert.Error(t, err, ErrNoPreviousMeasurements)
 
 	expectedCtx.From = "@1"
-	expectedCtx.RecordToSession = true
 	assert.Equal(t, expectedCtx, ctx)
 	assert.Equal(t, "Error: no previous measurements found\n", w.String())
 
 	w.Reset()
+	ctx = createDefaultContext("ping")
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@0"}
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.Error(t, err, ErrInvalidIndex)
 
 	expectedCtx.From = "@0"
-	expectedCtx.RecordToSession = true
 	assert.Equal(t, expectedCtx, ctx)
 	assert.Equal(t, "Error: invalid index\n", w.String())
 
 	w.Reset()
+	ctx = createDefaultContext("ping")
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@x"}
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.Error(t, err, ErrInvalidIndex)
 
 	expectedCtx.From = "@x"
-	expectedCtx.RecordToSession = true
 	assert.Equal(t, expectedCtx, ctx)
 	assert.Equal(t, "Error: invalid index\n", w.String())
 
 	w.Reset()
+	ctx = createDefaultContext("ping")
 	root = NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@"}
 	err = root.Cmd.ExecuteContext(context.TODO())
 	assert.Error(t, err, ErrInvalidIndex)
 
 	expectedCtx.From = "@"
-	expectedCtx.RecordToSession = true
 	assert.Equal(t, expectedCtx, ctx)
 	assert.Equal(t, "Error: invalid index\n", w.String())
 }
@@ -322,6 +325,8 @@ func Test_Execute_Ping_Infinite(t *testing.T) {
 	printer := view.NewPrinter(nil, w, w)
 	ctx := &view.Context{
 		History: view.NewHistoryBuffer(10),
+		From:    "world",
+		Limit:   1,
 	}
 	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "--infinite", "from", "Berlin"}
@@ -420,7 +425,7 @@ func Test_Execute_Ping_Infinite_Output_Error(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("ping")
 	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "--infinite", "from", "Berlin"}
 	err := root.Cmd.ExecuteContext(context.TODO())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,15 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var fromShortDesc = `Comma-separated list of location values to match against or a measurement ID
-  For example, the partial or full name of a continent, region (e.g eastern europe), country, US state, city or network
-  Or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements.`
-var limitShortDesc = `Limit the number of probes to use`
-var jsonShortDesc = `Output results in JSON format (default false)`
-var ciModeShortDesc = `Disable realtime terminal updates and color suitable for CI and scripting (default false)`
-var latencyShortDesc = `Output only the stats of a measurement (default false)`
-var shareShortDesc = `Prints a link at the end the results, allowing to vizualize the results online (default false)`
-
 type Root struct {
 	printer *view.Printer
 	ctx     *view.Context
@@ -85,6 +76,16 @@ The CLI tool allows you to interact with the API in a simple and human-friendly 
 
 	root.Cmd.SetOut(printer.OutWriter)
 	root.Cmd.SetErr(printer.ErrWriter)
+	// Global flags
+	flags := root.Cmd.PersistentFlags()
+	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `Comma-separated list of location values to match against or a measurement ID
+	For example, the partial or full name of a continent, region (e.g eastern europe), country, US state, city or network
+	Or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements.`)
+	flags.IntVarP(&ctx.Limit, "limit", "L", ctx.Limit, "Limit the number of probes to use")
+	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "Output results in JSON format (default false)")
+	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "Disable realtime terminal updates and color suitable for CI and scripting (default false)")
+	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "Output only the stats of a measurement (default false). Only applies to the dns, http and ping commands")
+	flags.BoolVar(&ctx.Share, "share", ctx.Share, "Prints a link at the end the results, allowing to vizualize the results online (default false)")
 
 	root.Cmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,6 @@ func Execute() {
 	if err != nil {
 		os.Exit(1)
 	}
-	root.UpdateHistory()
 }
 
 func NewRoot(

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -47,12 +47,6 @@ Examples:
 
 	// traceroute specific flags
 	flags := tracerouteCmd.Flags()
-	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
-	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
-	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
-	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
-	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
-	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
 	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol used for tracerouting (ICMP, TCP or UDP) (default \"icmp\")")
 	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use for the traceroute. Only applicable for TCP protocol (default 80)")
 

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/spf13/cobra"
 )
 
@@ -46,8 +47,14 @@ Examples:
 
 	// traceroute specific flags
 	flags := tracerouteCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", "", "Specifies the protocol used for tracerouting (ICMP, TCP or UDP) (default \"icmp\")")
-	flags.IntVar(&r.ctx.Port, "port", 0, "Specifies the port to use for the traceroute. Only applicable for TCP protocol (default 80)")
+	flags.StringVarP(&r.ctx.From, "from", "F", r.ctx.From, fromShortDesc)
+	flags.IntVarP(&r.ctx.Limit, "limit", "L", r.ctx.Limit, limitShortDesc)
+	flags.BoolVarP(&r.ctx.ToJSON, "json", "J", r.ctx.ToJSON, jsonShortDesc)
+	flags.BoolVarP(&r.ctx.CIMode, "ci", "C", r.ctx.CIMode, ciModeShortDesc)
+	flags.BoolVar(&r.ctx.ToLatency, "latency", r.ctx.ToLatency, latencyShortDesc)
+	flags.BoolVar(&r.ctx.Share, "share", r.ctx.Share, shareShortDesc)
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol used for tracerouting (ICMP, TCP or UDP) (default \"icmp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use for the traceroute. Only applicable for TCP protocol (default 80)")
 
 	r.Cmd.AddCommand(tracerouteCmd)
 }
@@ -89,7 +96,12 @@ func (r *Root) RunTraceroute(cmd *cobra.Command, args []string) error {
 	}
 
 	r.ctx.MeasurementsCreated++
-
+	hm := &view.HistoryItem{
+		Id:        res.ID,
+		Status:    globalping.StatusInProgress,
+		StartedAt: r.time.Now(),
+	}
+	r.ctx.History.Push(hm)
 	if r.ctx.RecordToSession {
 		r.ctx.RecordToSession = false
 		err := saveIdToSession(res.ID)

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -63,6 +63,7 @@ func (r *Root) RunTraceroute(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("the latency flag is not supported by the traceroute command")
 	}
 
+	defer r.UpdateHistory()
 	r.ctx.RecordToSession = true
 
 	opts := &globalping.MeasurementCreate{

--- a/cmd/traceroute_test.go
+++ b/cmd/traceroute_test.go
@@ -33,7 +33,7 @@ func Test_Execute_Traceroute_Default(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
-	ctx := createDefaultContext()
+	ctx := createDefaultContext("traceroute")
 	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
 	os.Args = []string{"globalping", "traceroute", "jsdelivr.com",
 		"from", "Berlin",

--- a/cmd/traceroute_test.go
+++ b/cmd/traceroute_test.go
@@ -63,6 +63,7 @@ func Test_Execute_Traceroute_Default(t *testing.T) {
 	b, err = os.ReadFile(getHistoryPath())
 	assert.NoError(t, err)
 	expectedHistory = createDefaultExpectedHistoryLogItem(
+		"1",
 		measurementID1,
 		"traceroute jsdelivr.com from Berlin --limit 2 --protocol tcp --port 99",
 	)

--- a/cmd/traceroute_test.go
+++ b/cmd/traceroute_test.go
@@ -31,10 +31,13 @@ func Test_Execute_Traceroute_Default(t *testing.T) {
 	viewerMock := mocks.NewMockViewer(ctrl)
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
+	timeMock := mocks.NewMockTime(ctrl)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
 	ctx := createDefaultContext("traceroute")
-	root := NewRoot(printer, ctx, viewerMock, nil, gbMock, nil)
+	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "traceroute", "jsdelivr.com",
 		"from", "Berlin",
 		"--limit", "2",

--- a/cmd/traceroute_test.go
+++ b/cmd/traceroute_test.go
@@ -32,7 +32,7 @@ func Test_Execute_Traceroute_Default(t *testing.T) {
 	viewerMock.EXPECT().Output(measurementID1, expectedOpts).Times(1).Return(nil)
 
 	timeMock := mocks.NewMockTime(ctrl)
-	timeMock.EXPECT().Now().Return(defaultCurrentTime).Times(1)
+	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
 	printer := view.NewPrinter(nil, w, w)
@@ -57,6 +57,14 @@ func Test_Execute_Traceroute_Default(t *testing.T) {
 
 	b, err := os.ReadFile(getMeasurementsPath())
 	assert.NoError(t, err)
-	expectedHistory := []byte(measurementID1 + "\n")
-	assert.Equal(t, expectedHistory, b)
+	expectedHistory := measurementID1 + "\n"
+	assert.Equal(t, expectedHistory, string(b))
+
+	b, err = os.ReadFile(getHistoryPath())
+	assert.NoError(t, err)
+	expectedHistory = createDefaultExpectedHistoryLogItem(
+		measurementID1,
+		"traceroute jsdelivr.com from Berlin --limit 2 --protocol tcp --port 99",
+	)
+	assert.Equal(t, expectedHistory, string(b))
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"time"
@@ -113,4 +114,17 @@ func createDefaultExpectedContext(cmd string) *view.Context {
 		StartedAt: defaultCurrentTime,
 	})
 	return ctx
+}
+
+func createDefaultExpectedHistoryLogItem(measurements string, cmd string) string {
+	return fmt.Sprintf("%d|%d|%s|%s\n",
+		HistoryItemVersion1,
+		defaultCurrentTime.Unix(),
+		measurements,
+		cmd,
+	)
+}
+
+func createDefaultExpectedHistoryItem(index int, time string, measurements string) string {
+	return fmt.Sprintf("%d | %s | ping jsdelivr.com\n> https://www.jsdelivr.com/globalping?measurement=%s\n", index, time, measurements)
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -107,12 +107,10 @@ func createDefaultExpectedContext(cmd string) *view.Context {
 		History:             view.NewHistoryBuffer(1),
 		MeasurementsCreated: 1,
 	}
-	if cmd == "ping" {
-		ctx.History.Push(&view.HistoryItem{
-			Id:        measurementID1,
-			Status:    globalping.StatusInProgress,
-			StartedAt: defaultCurrentTime,
-		})
-	}
+	ctx.History.Push(&view.HistoryItem{
+		Id:        measurementID1,
+		Status:    globalping.StatusInProgress,
+		StartedAt: defaultCurrentTime,
+	})
 	return ctx
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -116,15 +116,16 @@ func createDefaultExpectedContext(cmd string) *view.Context {
 	return ctx
 }
 
-func createDefaultExpectedHistoryLogItem(measurements string, cmd string) string {
-	return fmt.Sprintf("%d|%d|%s|%s\n",
+func createDefaultExpectedHistoryLogItem(index, measurements string, cmd string) string {
+	return fmt.Sprintf("%s|%s|%d|%s|%s\n",
 		HistoryItemVersion1,
+		index,
 		defaultCurrentTime.Unix(),
 		measurements,
 		cmd,
 	)
 }
 
-func createDefaultExpectedHistoryItem(index int, time string, measurements string) string {
-	return fmt.Sprintf("%d | %s | ping jsdelivr.com\n> https://www.jsdelivr.com/globalping?measurement=%s\n", index, time, measurements)
+func createDefaultExpectedHistoryItem(index string, time string, cmd string, measurements string) string {
+	return fmt.Sprintf("%s | %s | %s\n> https://www.jsdelivr.com/globalping?measurement=%s\n", index, time, cmd, measurements)
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -88,10 +88,13 @@ func createDefaultMeasurement_MultipleProbes(cmd string, status globalping.Measu
 	}
 }
 
-func createDefaultContext() *view.Context {
-	return &view.Context{
+func createDefaultContext(_ string) *view.Context {
+	ctx := &view.Context{
 		History: view.NewHistoryBuffer(1),
+		From:    "world",
+		Limit:   1,
 	}
+	return ctx
 }
 
 func createDefaultExpectedContext(cmd string) *view.Context {

--- a/view/context.go
+++ b/view/context.go
@@ -34,7 +34,8 @@ type Context struct {
 
 	APIMinInterval time.Duration // Minimum interval between API calls
 
-	RecordToSession bool // Record measurement to session history
+	IsLocationFromSession bool // Determine whether the previous location is used
+	RecordToSession       bool // Record measurement to session history
 
 	Hostname            string
 	IsHeaderPrinted     bool

--- a/view/context.go
+++ b/view/context.go
@@ -29,8 +29,8 @@ type Context struct {
 	Full      bool // Full output
 	Infinite  bool // Infinite flag
 
-	First uint // Number of first measurements to show
-	Last  uint // Number of last measurements to show
+	Head uint // Number of first measurements to show
+	Tail uint // Number of last measurements to show
 
 	APIMinInterval time.Duration // Minimum interval between API calls
 

--- a/view/context.go
+++ b/view/context.go
@@ -29,6 +29,9 @@ type Context struct {
 	Full      bool // Full output
 	Infinite  bool // Infinite flag
 
+	First uint // Number of first measurements to show
+	Last  uint // Number of last measurements to show
+
 	APIMinInterval time.Duration // Minimum interval between API calls
 
 	RecordToSession bool // Record measurement to session history

--- a/view/output.go
+++ b/view/output.go
@@ -10,6 +10,8 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
+var ShareURL = "https://www.jsdelivr.com/globalping?measurement="
+
 func (v *viewer) Output(id string, m *globalping.MeasurementCreate) error {
 	// Wait for first result to arrive from a probe before starting display (can be in-progress)
 	data, err := v.globalping.GetMeasurement(id)
@@ -140,7 +142,7 @@ func (v *viewer) getProbeInfo(result *globalping.ProbeMeasurement) string {
 }
 
 func (v *viewer) getShareMessage(id string) string {
-	m := fmt.Sprintf("> View the results online: https://www.jsdelivr.com/globalping?measurement=%s", id)
+	m := fmt.Sprintf("> View the results online: %s%s", ShareURL, id)
 	if v.ctx.CIMode {
 		return m
 	}


### PR DESCRIPTION
 - adds new command `history` (#89)

```bash
globalping history
1 | 2024-03-27 11:56:46 | ping google.com
> https://www.jsdelivr.com/globalping?measurement=itcR65tYCqbouXib
- | 2024-03-27 11:57:01 | dns google.com from last
> https://www.jsdelivr.com/globalping?measurement=kWc5UBK9A6G4RUYM
2 | 2024-03-27 11:57:20 | traceroute google.com from New York --limit 2
> https://www.jsdelivr.com/globalping?measurement=Yz7A1UifUonZsC3C
3 | 2024-03-27 11:57:37 | mtr google.com from New York --limit 2
> https://www.jsdelivr.com/globalping?measurement=SX1NBgfDKiabM1vZ
4 | 2024-03-27 11:57:52 | http google.com from London,Belgium --limit 2 --method get --ci
> https://www.jsdelivr.com/globalping?measurement=eclwFSYX0zgU10Cs

globalping history --first 2
1 | 2024-03-27 11:56:46 | ping google.com
> https://www.jsdelivr.com/globalping?measurement=itcR65tYCqbouXib
- | 2024-03-27 11:57:01 | dns google.com from last
> https://www.jsdelivr.com/globalping?measurement=kWc5UBK9A6G4RUYM

globalping history --last 2
4 | 2024-03-27 11:57:52 | http google.com from London,Belgium --limit 2 --method get --ci
> https://www.jsdelivr.com/globalping?measurement=eclwFSYX0zgU10Cs
3 | 2024-03-27 11:57:37 | mtr google.com from New York --limit 2
> https://www.jsdelivr.com/globalping?measurement=SX1NBgfDKiabM1vZ
```