### PR TITLE
misc: update packagecloud release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,13 @@ jobs:
             dist/globalping_Windows_x86_64.zip
             dist/globalping_Windows_i386.zip
 
-  deploy:
+  release_linux:
     needs: goreleaser
     runs-on: ubuntu-latest
+    env:
+      PACKAGECLOUD_USER: jsdelivr
+      PACKAGECLOUD_REPO: globalping
+      PACKAGECLOUD_APIKEY: ${{ secrets.PACKAGECLOUD_APIKEY }}
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -62,21 +66,28 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: goreleaser-rpm
+
+      - run: echo "VERSION_NAME=${GITHUB_REF_NAME:1}" >> $GITHUB_ENV
+      - run: ls -la
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.22"
+          cache: true
+
+      - run: go run packagecloud/main.go "globalping_${{ env.VERSION_NAME }}_linux_amd64.deb" "deb"
+      - run: go run packagecloud/main.go "globalping_${{ env.VERSION_NAME }}_linux_amd64.rpm" "rpm"
+
+  release_windows:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/download-artifact@v3
         with:
           name: goreleaser-windows
 
       - run: echo "VERSION_NAME=${GITHUB_REF_NAME:1}" >> $GITHUB_ENV
       - run: ls -la
-
-      - name: Release to Packagecloud
-        uses: jsdelivr/upload-packagecloud@v3
-        with:
-          deb-package-name: globalping_${{ env.VERSION_NAME }}_linux_amd64.deb
-          rpm-package-name: globalping_${{ env.VERSION_NAME }}_linux_amd64.rpm
-          packagecloud-username: jsdelivr
-          packagecloud-repo: globalping
-          packagecloud-token: ${{ secrets.PACKAGECLOUD_APIKEY }}
 
       - name: Release to Winget
         uses: vedantmgoyal2009/winget-releaser@v2

--- a/packagecloud/main.go
+++ b/packagecloud/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+)
+
+const (
+	PackagecloudAPIURL = "https://packagecloud.io/api/v1/repos/"
+	PackagecloudDEBAny = "35"
+	PackagecloudRPMAny = "227"
+)
+
+type Config struct {
+	PackagecloudUser   string
+	PackagecloudRepo   string
+	PackagecloudAPIKey string
+}
+
+func main() {
+	file := os.Args[1]
+	dist := os.Args[2]
+	if file == "" || dist == "" {
+		fmt.Println("Usage: upload <path> <dist>")
+		os.Exit(1)
+	}
+	config := &Config{
+		PackagecloudUser:   os.Getenv("PACKAGECLOUD_USER"),
+		PackagecloudRepo:   os.Getenv("PACKAGECLOUD_REPO"),
+		PackagecloudAPIKey: os.Getenv("PACKAGECLOUD_APIKEY"),
+	}
+	switch dist {
+	case "deb":
+		log.Printf("Uploading DEB package: %s\n", file)
+		err := uploadPackage(config, PackagecloudDEBAny, file)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		log.Println("DEB package uploaded")
+	case "rpm":
+		log.Printf("Uploading RPM package: %s\n", file)
+		err := uploadPackage(config, PackagecloudRPMAny, file)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		log.Println("RPM package uploaded")
+	default:
+		fmt.Println("Unknown distro")
+		os.Exit(1)
+	}
+}
+
+func uploadPackage(config *Config, distroVersionId string, path string) error {
+	var body bytes.Buffer
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("package[package_file]", f.Name())
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, f)
+	if err != nil {
+		return err
+	}
+	err = writer.WriteField("package[distro_version_id]", distroVersionId)
+	if err != nil {
+		return err
+	}
+	err = writer.Close()
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", PackagecloudAPIURL+config.PackagecloudUser+"/"+config.PackagecloudRepo+"/packages.json", &body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetBasicAuth(config.PackagecloudAPIKey, "")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(b))
+	}
+	return nil
+}


### PR DESCRIPTION
Fix for #77 
- drops `jsdelivr/upload-packagecloud@v3` action
- uploads `.deb` artifact to `deb/any` (35)
- uploads `.rpm` artifact to `rpm/rpm_any` (227)
