### PR TITLE
docs: revise help screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,35 +77,38 @@ After installing, verify the Globalping CLI is working by running:
 The result shows how to use the CLI and which commands and flags are available:
 
 ```bash
-Globalping is a platform that allows anyone to run networking commands such as ping, traceroute, dig and mtr on probes distributed all around the world.
-The CLI tool allows you to interact with the API in a simple and human-friendly way to debug networking issues like anycast routing and script automated tests and benchmarks.
-
 Usage:
   globalping [command]
 
 Measurement Commands:
-  dns           Resolve a DNS record similarly to dig
+  dns           Resolve DNS records, similar to the dig command
   http          Perform a HEAD or GET request to a host
-  mtr           Run an MTR test, similar to traceroute
-  ping          Run a ping test
+  mtr           Run a MTR test, which combines traceroute and ping
+  ping          Perform a ping test
   traceroute    Run a traceroute test
 
 Additional Commands:
   completion    Generate the autocompletion script for the specified shell
   help          Help about any command
-  history       Show the history of your measurements in your current session
-  install-probe Join the community powered Globalping platform by running a Docker container.
-  version       Print the version number of Globalping CLI
+  history       Display the measurement history of your current session
+  install-probe Join the Globalping network by running a probe
+  version       Display the version of your installed Globalping CLI
 
 Flags:
-  -C, --ci            Disable realtime terminal updates and color suitable for CI and scripting (default false)
-  -F, --from string   Comma-separated list of location values to match against or a measurement ID
-                      For example, the partial or full name of a continent, region (e.g eastern europe), country, US state, city or network
-                      Or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements. (default "world")
+  -C, --ci            disable real-time terminal updates and colors, suitable for CI and scripting
+                      (default false)
+  -F, --from string   specify the probe locations as a comma-separated list; you may use:
+                       - names of continents, regions, countries, US states, cities, or networks
+                       - [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from
+                      previous measurements in this session
+                       - an ID of a previous measurement to run with its probes
+                       (default "world")
   -h, --help          help for globalping
-  -J, --json          Output results in JSON format (default false)
-      --latency       Output only the stats of a measurement (default false). Only applies to the dns, http and ping commands
-  -L, --limit int     Limit the number of probes to use (default 1)
+  -J, --json          output results in JSON format (default false)
+      --latency       output only the latency stats; applicable only to dns, http, and ping commands
+                      (default false)
+  -L, --limit int     define the number of probes to use (default 1)
+      --share         print a link at the end of the results to visualize them online (default false)
 
 Use "globalping [command] --help" for more information about a command.
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After installing, verify the Globalping CLI is working by running:
 
 The result shows how to use the CLI and which commands and flags are available:
 
-```bash
+```
 Usage:
   globalping [command]
 

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -11,7 +11,7 @@ func (r *Root) initDNS() {
 		RunE:    r.RunDNS,
 		Use:     "dns [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Resolve DNS records, similar to the dig command.",
+		Short:   "Resolve DNS records, similar to the dig command",
 		Long: `The dns command (similar to the "dig" command) performs DNS lookups and displays the responses from the queried name servers, helping you troubleshoot DNS-related issues.
 Note that a probe's local settings or DHCP determine the default nameserver the command uses. To specify a DNS resolver, use the --resolver argument or @resolver format: 
 - dns jsdelivr.com from Berlin --resolver 1.1.1.1
@@ -54,11 +54,11 @@ Note that a probe's local settings or DHCP determine the default nameserver the 
 
 	// dns specific flags
 	flags := dnsCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use for the DNS query: TCP or UDP. (default \"udp\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify a non-standard port on the server to send the query to. (default 53)")
-	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specify the hostname or IP address of the name server to use as the resolver. (default defined by the probe)")
-	flags.StringVar(&r.ctx.QueryType, "type", r.ctx.QueryType, "Specify the type of DNS query to perform. (default \"A\")")
-	flags.BoolVar(&r.ctx.Trace, "trace", r.ctx.Trace, "Enable tracing of the delegation path from the root name servers. (default false)")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "specify the protocol to use for the DNS query: TCP or UDP (default \"udp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "specify a non-standard port on the server to send the query to (default 53)")
+	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "specify the hostname or IP address of the name server to use as the resolver (default defined by the probe)")
+	flags.StringVar(&r.ctx.QueryType, "type", r.ctx.QueryType, "specify the type of DNS query to perform (default \"A\")")
+	flags.BoolVar(&r.ctx.Trace, "trace", r.ctx.Trace, "enable tracing of the delegation path from the root name servers (default false)")
 
 	r.Cmd.AddCommand(dnsCmd)
 }

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -11,54 +11,54 @@ func (r *Root) initDNS() {
 		RunE:    r.RunDNS,
 		Use:     "dns [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Resolve a DNS record similarly to dig",
-		Long: `Performs DNS lookups and displays the answers that are returned from the name server(s) that were queried.
-The default nameserver depends on the probe and is defined by the user's local settings or DHCP.
-This command provides 2 different ways to provide the dns resolver:
-Using the --resolver argument. For example:
-  dns jsdelivr.com from Berlin --resolver 1.1.1.1
-Using the dig format @resolver. For example:
-  dns jsdelivr.com @1.1.1.1 from Berlin
+		Short:   "Resolve DNS records, similar to the dig command.",
+		Long: `The dns command (similar to the "dig" command) performs DNS lookups and displays the responses from the queried name servers, helping you troubleshoot DNS-related issues.
+Note that a probe's local settings or DHCP determine the default nameserver the command uses. To specify a DNS resolver, use the --resolver argument or @resolver format: 
+- dns jsdelivr.com from Berlin --resolver 1.1.1.1
+- dns jsdelivr.com @1.1.1.1 from Berlin
 
   Examples:
-  # Resolve google.com from 2 probes in New York
+  # Resolve google.com from 2 probes in New York.
   dns google.com from New York --limit 2
 
-  # Resolve google.com using probes from previous measurement
+  # Resolve google.com using probes from a previous measurement by using its ID.
   dns google.com from rvasVvKnj48cxNjC
 
-  # Resolve google.com using probes from first measurement in session
+  # Resolve google.com using the same probes from the first measurement in this session.
   dns google.com from @1
 
-  # Resolve google.com using probes from last measurement in session
+  # Resolve google.com using the same probes from the last measurement in this session.
   dns google.com from last
 
-  # Resolve google.com using probes from second to last measurement in session
+  # Resolve google.com using the same probes from the second-to-last measurement in this session.
   dns google.com from @-2
 
-  # Resolve google.com from 2 probes from London or Belgium with trace enabled
+  # Resolve google.com from 2 probes from London or Belgium with trace enabled.
   dns google.com from London,Belgium --limit 2 --trace
 
-  # Resolve google.com from a probe in Paris using the TCP protocol
+  # Resolve google.com from a probe in Paris using the TCP protocol.
   dns google.com from Paris --protocol tcp
 
-  # Resolve jsdelivr.com from a probe in Berlin using the type MX and the resolver 1.1.1.1 in CI mode
+  # Resolve the MX records for jsdelivr.com from a probe in Berlin with the resolver 1.1.1.1 and enable CI mode.
   dns jsdelivr.com from Berlin --type MX --resolver 1.1.1.1 --ci
 
-  # Resolve jsdelivr.com from a probe that is from the AWS network and is located in Montreal with latency output
+  # Resolve jsdelivr.com from a probe on the AWS network located in Montreal and display only latency information.
   dns jsdelivr.com from aws+montreal --latency
 
-  # Resolve jsdelivr.com from a probe in ASN 123 with json output
-  dns jsdelivr.com from 123 --json`,
+  # Resolve jsdelivr.com from a probe in ASN 123 and output the results in JSON format.
+  dns jsdelivr.com from 123 --json
+  
+  # Resolve jsdelivr.com from a non-data center probe in Europe and add a link to view the results online..
+  dns jsdelivr.com from europe+eyeball --share`,
 	}
 
 	// dns specific flags
 	flags := dnsCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol to use for the DNS query (TCP or UDP) (default \"udp\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Send the query to a non-standard port on the server (default 53)")
-	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Resolver is the hostname or IP address of the name server to use (default empty)")
-	flags.StringVar(&r.ctx.QueryType, "type", r.ctx.QueryType, "Specifies the type of DNS query to perform (default \"A\")")
-	flags.BoolVar(&r.ctx.Trace, "trace", r.ctx.Trace, "Toggle tracing of the delegation path from the root name servers (default false)")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use for the DNS query: TCP or UDP. (default \"udp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify a non-standard port on the server to send the query to. (default 53)")
+	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specify the hostname or IP address of the name server to use as the resolver. (default defined by the probe)")
+	flags.StringVar(&r.ctx.QueryType, "type", r.ctx.QueryType, "Specify the type of DNS query to perform. (default \"A\")")
+	flags.BoolVar(&r.ctx.Trace, "trace", r.ctx.Trace, "Enable tracing of the delegation path from the root name servers. (default false)")
 
 	r.Cmd.AddCommand(dnsCmd)
 }

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -17,7 +17,7 @@ Note that a probe's local settings or DHCP determine the default nameserver the 
 - dns jsdelivr.com from Berlin --resolver 1.1.1.1
 - dns jsdelivr.com @1.1.1.1 from Berlin
 
-  Examples:
+Examples:
   # Resolve google.com from 2 probes in New York.
   dns google.com from New York --limit 2
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -34,7 +34,7 @@ func (r *Root) initHistory() {
 	historyCmd := &cobra.Command{
 		Run:   r.RunHistory,
 		Use:   "history",
-		Short: "Display the measurement history of your current session.",
+		Short: "Display the measurement history of your current session",
 		Long: `Display the measurement history of your current session.
 Examples:
   # Display all measurements of the current session.
@@ -48,8 +48,8 @@ Examples:
 	}
 
 	flags := historyCmd.Flags()
-	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "Specify the number of measurements to display from the beginning of the history.")
-	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "Specify the number of measurements to display from the end of the history.")
+	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "specify the number of measurements to display from the beginning of the history")
+	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "specify the number of measurements to display from the end of the history")
 
 	r.Cmd.AddCommand(historyCmd)
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -36,6 +36,7 @@ func (r *Root) initHistory() {
 		Use:   "history",
 		Short: "Display the measurement history of your current session",
 		Long: `Display the measurement history of your current session.
+
 Examples:
   # Display all measurements of the current session.
   history

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -34,22 +34,22 @@ func (r *Root) initHistory() {
 	historyCmd := &cobra.Command{
 		Run:   r.RunHistory,
 		Use:   "history",
-		Short: "Show the history of your measurements in your current session",
-		Long: `Show the history of your measurements in your current session
+		Short: "Display the measurement history of your current session.",
+		Long: `Display the measurement history of your current session.
 Examples:
-  # Show all the measurements
+  # Display all measurements of the current session.
   history
 
-  # Show the first 5 measurements
+  # Display the first 5 measurements of the current session.
   history --head 5
 
-  # Show the last 10 measurements
+  # Display the last 10 measurements of the current session.
   history --tail 10`,
 	}
 
 	flags := historyCmd.Flags()
-	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "Number of measurements to show from the beginning of the history")
-	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "Number of measurements to show from the end of the history")
+	flags.UintVar(&r.ctx.Head, "head", r.ctx.Head, "Specify the number of measurements to display from the beginning of the history.")
+	flags.UintVar(&r.ctx.Tail, "tail", r.ctx.Tail, "Specify the number of measurements to display from the end of the history.")
 
 	r.Cmd.AddCommand(historyCmd)
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -18,7 +18,7 @@ func (r *Root) initHTTP() {
 		RunE:    r.RunHTTP,
 		Use:     "http [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Perform a HEAD or GET request to a host.",
+		Short:   "Perform a HEAD or GET request to a host",
 		Long: `The http command sends an HTTP request to a host and can perform either HEAD or GET operations, returning detailed performance statistics for each request. Use it to test and assess the performance and availability of your website, API, or other web services. 
 Note that GET responses are limited to 10KB, with anything beyond this cut by the API. 
 
@@ -69,15 +69,15 @@ Examples:
 
 	// http specific flags
 	flags := httpCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use: HTTP, HTTPS, or HTTP2.  (default \"HTTP\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify the port to use. (default 80 for HTTP, 443 for HTTPS and HTTP2)")
-	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specify the hostname or IP address of the name server to use for the DNS lookup. (default defined by the probe)")
-	flags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "Specify the Host header to add to the request. (default host's defined in command target)")
-	flags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "Specify the URL pathname. (default \"/\")")
-	flags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "Specify a query string to add.")
-	flags.StringVar(&r.ctx.Method, "method", r.ctx.Method, "Specify the HTTP method to use: HEAD or GET. (default \"HEAD\")")
-	flags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "Specify an HTTP header to add to the request in the format \"Key: Value\". You can add multiple headers by providing the flag for each one separately.")
-	flags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "Enable full output when performing an HTTP GET request to display the status, headers, and body.")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "specify the protocol to use: HTTP, HTTPS, or HTTP2  (default \"HTTP\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "specify the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
+	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "specify the hostname or IP address of the name server to use for the DNS lookup (default defined by the probe)")
+	flags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "specify the Host header to add to the request (default host's defined in command target)")
+	flags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "specify the URL pathname (default \"/\")")
+	flags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "specify a query string to add")
+	flags.StringVar(&r.ctx.Method, "method", r.ctx.Method, "specify the HTTP method to use: HEAD or GET (default \"HEAD\")")
+	flags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "add HTTP headers to the request in the format \"Key: Value\"; to add multiple headers, define the flag for each one separately")
+	flags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "enable full output when performing an HTTP GET request to display the status, headers, and body")
 
 	r.Cmd.AddCommand(httpCmd)
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -18,66 +18,66 @@ func (r *Root) initHTTP() {
 		RunE:    r.RunHTTP,
 		Use:     "http [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Perform a HEAD or GET request to a host",
-		Long: `The http command sends an HTTP request to a host and can perform HEAD or GET operations. GET is limited to 10KB responses, everything above will be cut by the API. Detailed performance stats as available for every request.
-The tool supports 2 formats for this command:
-When the full url is supplied, the tool autoparses the scheme, host, port, domain, path and query. For example:
-  http https://www.jsdelivr.com:443/package/npm/test?nav=stats
-As an alternative that can be useful for scripting, the scheme, host, port, domain, path and query can be provided as separate command line flags. For example:
-  http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"
+		Short:   "Perform a HEAD or GET request to a host.",
+		Long: `The http command sends an HTTP request to a host and can perform either HEAD or GET operations, returning detailed performance statistics for each request. Use it to test and assess the performance and availability of your website, API, or other web services. 
+Note that GET responses are limited to 10KB, with anything beyond this cut by the API. 
 
-This command also provides 2 different ways to provide the dns resolver:
-Using the --resolver argument. For example:
- http jsdelivr.com from Berlin --resolver 1.1.1.1
-Using the dig format @resolver. For example:
- http jsdelivr.com @1.1.1.1 from Berlin
+The CLI tool supports two formats: 
+1. Full URL: The tool automatically parses the scheme, host, port, domain, path, and query. For example:
+	http https://www.jsdelivr.com:443/package/npm/test?nav=stats
+2. Separate flags: Specify the scheme, host, port, domain, path, and query as separate command line flags, useful for scripting. For example:
+	http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"
+
+Note that a probe's local settings or DHCP determine the default nameserver the command uses. To specify a DNS resolver, use the --resolver argument or @resolver format:  
+- http jsdelivr.com from Berlin --resolver 1.1.1.1
+- http jsdelivr.com @1.1.1.1 from Berlin
 
 Examples:
-  # HTTP HEAD request to jsdelivr.com from 2 probes in New York (protocol, port and path are inferred from the URL)
+  # Perform an HTTP HEAD request to jsdelivr.com from 2 probes in New York. Protocol, port, and path are derived from the URL.
   http https://www.jsdelivr.com:443/package/npm/test?nav=stats from New York --limit 2
 
-  # HTTP GET request to google.com from 2 probes from London or Belgium in CI mode
+  # Perform an HTTP GET request to google.com from 2 probes from London or Belgium and enable CI mode.
   http google.com from London,Belgium --limit 2 --method get --ci
 
-  # HTTP GET request google.com using probes from previous measurement
+  # Perform an HTTP GET request to google.com using probes from a previous measurement by using its ID.
   http google.com from rvasVvKnj48cxNjC --method get
 
-  # HTTP GET request google.com using probes from first measurement in session
+  # Perform an HTTP GET request to google.com using the same probes from the first measurement in this session.
   http google.com from @1 --method get
 
-  # HTTP GET request google.com using probes from last measurement in session
+  # Perform an HTTP GET request to google.com using the same probes from the last measurement in this session.
   http google.com from last --method get
 
-  # HTTP GET request google.com using probes from second to last measurement in session
+  # Perform an HTTP GET request to google.com using the same probes from the second-to-last measurement in this session.
   http google.com from @-2 --method get
 
-  # HTTP GET request to google.com from a probe in London. Returns the full output
+  # Perform an HTTP GET request to google.com from a probe in London and return the full output.
   http google.com from London --method get --full
 
-  # HTTP HEAD request to jsdelivr.com from a probe that is from the AWS network and is located in Montreal using HTTP2. 2 http headers are added to the request.
+  # Perform an HTTP HEAD request to jsdelivr.com from a probe on the AWS network located in Montreal using HTTP2. Include the http headers "Accept-Encoding" and "Accept-Language" to the request.
   http jsdelivr.com from aws+montreal --protocol http2 --header "Accept-Encoding: br,gzip" -H "Accept-Language: *"
 
-  # HTTP HEAD request to jsdelivr.com from a probe that is located in Paris, using the /robots.txt path with "test=1" query string
-  http jsdelivr.com from Paris --path /robots.txt --query "test=1"
+  # Perform an HTTP HEAD request to jsdelivr.com from a non-data center probe in Europe and add the path /robots.txt and query string "test=1" to the request.
+  http jsdelivr.com from europe+eyeball --path /robots.txt --query "test=1"
 
-  # HTTP HEAD request to example.com from a probe that is located in Berlin, specifying a different host example.org in the request headers
+  # Perform an HTTP HEAD request to example.com from a probe in Berlin. Override the "Host" header by specifying a different host (example.org) from the target (example.com).
   http example.com from Berlin --host example.org
 
-  # HTTP GET request google.com from a probe in ASN 123 with a dns resolver 1.1.1.1 and json output
+  # Perform an HTTP GET request to google.com from a probe in ASN 123 using 1.1.1.1 as the DNS resolver and output the results in JSON format.
   http google.com from 123 --resolver 1.1.1.1 --json`,
 	}
 
 	// http specific flags
 	flags := httpCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the query protocol (HTTP, HTTPS, HTTP2) (default \"HTTP\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
-	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specifies the resolver server used for DNS lookup (default is defined by the probe's network)")
-	flags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "Specifies the Host header, which is going to be added to the request (default host defined in target)")
-	flags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "A URL pathname (default \"/\")")
-	flags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "A query-string")
-	flags.StringVar(&r.ctx.Method, "method", r.ctx.Method, "Specifies the HTTP method to use (HEAD or GET) (default \"HEAD\")")
-	flags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "Specifies a HTTP header to be added to the request, in the format \"Key: Value\". Multiple headers can be added by adding multiple flags")
-	flags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "Full output. Uses an HTTP GET request, and outputs the status, headers and body to the output")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use: HTTP, HTTPS, or HTTP2.  (default \"HTTP\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify the port to use. (default 80 for HTTP, 443 for HTTPS and HTTP2)")
+	flags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "Specify the hostname or IP address of the name server to use for the DNS lookup. (default defined by the probe)")
+	flags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "Specify the Host header to add to the request. (default host's defined in command target)")
+	flags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "Specify the URL pathname. (default \"/\")")
+	flags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "Specify a query string to add.")
+	flags.StringVar(&r.ctx.Method, "method", r.ctx.Method, "Specify the HTTP method to use: HEAD or GET. (default \"HEAD\")")
+	flags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "Specify an HTTP header to add to the request in the format \"Key: Value\". You can add multiple headers by providing the flag for each one separately.")
+	flags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "Enable full output when performing an HTTP GET request to display the status, headers, and body.")
 
 	r.Cmd.AddCommand(httpCmd)
 }

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -10,7 +10,7 @@ import (
 func (r *Root) initInstallProbe() {
 	installProbeCmd := &cobra.Command{
 		Use:   "install-probe",
-		Short: "Join the community-powered Globalping network by running a probe in a Docker container.",
+		Short: "Join the community-powered Globalping network by running a probe in a Docker container",
 		Long:  `The install-probe command downloads and runs the Globalping probe in a Docker container on your machine. Requires you to have Docker installed.`,
 		Run:   r.RunInstallProbe,
 	}

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -10,8 +10,8 @@ import (
 func (r *Root) initInstallProbe() {
 	installProbeCmd := &cobra.Command{
 		Use:   "install-probe",
-		Short: "Join the community powered Globalping platform by running a Docker container.",
-		Long:  `Pull and run the Globalping probe Docker container on this machine. It requires Docker to be installed.`,
+		Short: "Join the community-powered Globalping network by running a probe in a Docker container.",
+		Long:  `The install-probe command downloads and runs the Globalping probe in a Docker container on your machine. Requires you to have Docker installed.`,
 		Run:   r.RunInstallProbe,
 	}
 

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -10,7 +10,7 @@ import (
 func (r *Root) initInstallProbe() {
 	installProbeCmd := &cobra.Command{
 		Use:   "install-probe",
-		Short: "Join the community-powered Globalping network by running a probe in a Docker container",
+		Short: "Join the Globalping network by running a probe",
 		Long:  `The install-probe command downloads and runs the Globalping probe in a Docker container on your machine. Requires you to have Docker installed.`,
 		Run:   r.RunInstallProbe,
 	}

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -13,40 +13,43 @@ func (r *Root) initMTR() {
 		RunE:    r.RunMTR,
 		Use:     "mtr [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Run an MTR test, similar to traceroute",
-		Long: `mtr combines the functionality of the traceroute and ping programs in a single network diagnostic tool.
+		Short:   "Run a MTR test, which combines traceroute and ping.",
+		Long: `The MTR command combines the functionalities of traceroute and ping, providing real-time insights into the sent packets' routes. Use it to diagnose network issues such as packet loss, latency, and route instability.
 
 Examples:
-  # MTR google.com from 2 probes in New York
+  # MTR google.com from 2 probes in New York.
   mtr google.com from New York --limit 2
 
-  # MTR google.com using probes from previous measurement
+  # MTR google.com using probes from a previous measurement by using its ID.
   mtr google.com from rvasVvKnj48cxNjC
 
-  # MTR google.com using probes from first measurement in session
+  # MTR google.com using the same probes from the first measurement in this session.
   mtr google.com from @1
 
-  # MTR google.com using probes from last measurement in session
+  # MTR google.com using the same probes from the last measurement in this session.
   mtr google.com from last
 
-  # MTR google.com using probes from second to last measurement in session
+  # MTR google.com using the same probes from the second-to-last measurement in this session.
   mtr google.com from @-2
 
-  # MTR 1.1.1.1 from 2 probes from USA or Belgium with 10 packets in CI mode
+  # MTR 1.1.1.1 from 2 probes in the USA or Belgium. Send 10 packets and enable CI mode.
   mtr 1.1.1.1 from USA,Belgium --limit 2 --packets 10 --ci
 
-  # MTR jsdelivr.com from a probe that is from the AWS network and is located in Montreal using the TCP protocol and port 453
+  # MTR jsdelivr.com from a probe on the AWS network located in Montreal using the TCP protocol and port 453.
   mtr jsdelivr.com from aws+montreal --protocol tcp --port 453
 
-  # MTR jsdelivr.com from a probe in ASN 123 with json output
-  mtr jsdelivr.com from 123 --json`,
+  # MTR jsdelivr.com from a probe in ASN 123 and output the results in JSON format.
+  mtr jsdelivr.com from 123 --json
+  
+  # MTR jsdelivr.com from a non-data center probe in Europe and add a link to view the results online.
+  mtr jsdelivr.com from europe+eyeball --share `,
 	}
 
 	// mtr specific flags
 	flags := mtrCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol used (ICMP, TCP or UDP) (default \"icmp\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use. Only applicable for TCP protocol (default 53)")
-	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specifies the number of packets to send to each hop (default 3)")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use for MTR: ICMP, TCP, or UDP. (default \"icmp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify the port to use for MTR. Only applicable for the TCP protocol. (default 53)")
+	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specify the number of packets to send to each hop. (default 3)")
 
 	r.Cmd.AddCommand(mtrCmd)
 }

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -13,7 +13,7 @@ func (r *Root) initMTR() {
 		RunE:    r.RunMTR,
 		Use:     "mtr [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Run a MTR test, which combines traceroute and ping.",
+		Short:   "Run a MTR test, which combines traceroute and ping",
 		Long: `The MTR command combines the functionalities of traceroute and ping, providing real-time insights into the sent packets' routes. Use it to diagnose network issues such as packet loss, latency, and route instability.
 
 Examples:
@@ -47,9 +47,9 @@ Examples:
 
 	// mtr specific flags
 	flags := mtrCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use for MTR: ICMP, TCP, or UDP. (default \"icmp\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify the port to use for MTR. Only applicable for the TCP protocol. (default 53)")
-	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specify the number of packets to send to each hop. (default 3)")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "specify the protocol to use for MTR: ICMP, TCP, or UDP (default \"icmp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "specify the port to use for MTR; only applicable for the TCP protocol (default 53)")
+	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "specify the number of packets to send to each hop (default 3)")
 
 	r.Cmd.AddCommand(mtrCmd)
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -15,42 +15,45 @@ func (r *Root) initPing() {
 		RunE:    r.RunPing,
 		Use:     "ping [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Run a ping test",
-		Long: `The ping command allows sending ping requests to a target. Often used to test the network latency and stability.
+		Short:   "Perform a ping test.",
+		Long: `The ping command checks a target's reachability by sending small data packets. Use it to test network latency and stability, as well as obtain information about packet loss and round-trip times.
 
 Examples:
-  # Ping google.com from 2 probes in New York
+  # Ping google.com from 2 probes in New York.
   ping google.com from New York --limit 2
 
-  # Ping google.com using probes from previous measurement
+  # Ping google.com using probes from a previous measurement by using its ID.
   ping google.com from rvasVvKnj48cxNjC
 
-  # Ping google.com using probes from first measurement in session
+  # Ping google.com using the same probes from the first measurement in this session.
   ping google.com from @1
 
-  # Ping google.com using probes from last measurement in session
+  # Ping google.com using the same probes from the last measurement in this session.
   ping google.com from last
 
-  # Ping google.com using probes from second to last measurement in session
+  # Ping google.com using the same probes from the second-to-last measurement in this session.
   ping google.com from @-2
 
-  # Ping 1.1.1.1 from 2 probes from USA or Belgium with 10 packets in CI mode
+  # Ping 1.1.1.1 from 2 probes in the USA or Belgium. Send 10 packets and enable CI mode.
   ping 1.1.1.1 from USA,Belgium --limit 2 --packets 10 --ci
 
-  # Ping jsdelivr.com from a probe that is from the AWS network and is located in Montreal with latency output
+  # Ping jsdelivr.com from a probe on the AWS network located in Montreal and display only latency information.
   ping jsdelivr.com from aws+montreal --latency
 
-  # Ping jsdelivr.com from a probe in ASN 123 with json output
+  # Ping jsdelivr.com from a probe in ASN 123 and output the results in JSON format.
   ping jsdelivr.com from 123 --json
 
-  # Continuously ping google.com from New York
+  # Ping jsdelivr.com from a non-data center probe in Europe and add a link to view the results online.
+  ping jsdelivr.com from europe+eyeball --share
+
+  # Start a continuous ping to google.com from a probe in New York.
   ping google.com from New York --infinite`,
 	}
 
 	// ping specific flags
 	flags := pingCmd.Flags()
-	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specifies the desired amount of ECHO_REQUEST packets to be sent (default 3)")
-	flags.BoolVar(&r.ctx.Infinite, "infinite", r.ctx.Infinite, "Keep pinging the target continuously until stopped (default false)")
+	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specify the number of ECHO_REQUEST packets to send. (default 3)")
+	flags.BoolVar(&r.ctx.Infinite, "infinite", r.ctx.Infinite, "Enable continuous pinging of the target until manually stopped. (default false)")
 
 	r.Cmd.AddCommand(pingCmd)
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -15,7 +15,7 @@ func (r *Root) initPing() {
 		RunE:    r.RunPing,
 		Use:     "ping [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Perform a ping test.",
+		Short:   "Perform a ping test",
 		Long: `The ping command checks a target's reachability by sending small data packets. Use it to test network latency and stability, as well as obtain information about packet loss and round-trip times.
 
 Examples:
@@ -52,8 +52,8 @@ Examples:
 
 	// ping specific flags
 	flags := pingCmd.Flags()
-	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "Specify the number of ECHO_REQUEST packets to send. (default 3)")
-	flags.BoolVar(&r.ctx.Infinite, "infinite", r.ctx.Infinite, "Enable continuous pinging of the target until manually stopped. (default false)")
+	flags.IntVar(&r.ctx.Packets, "packets", r.ctx.Packets, "specify the number of ECHO_REQUEST packets to send (default 3)")
+	flags.BoolVar(&r.ctx.Infinite, "infinite", r.ctx.Infinite, "enable continuous pinging of the target until manually stopped (default false)")
 
 	r.Cmd.AddCommand(pingCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ func NewRoot(
 	// rootCmd represents the base command when called without any subcommands
 	root.Cmd = &cobra.Command{
 		Use:   "globalping",
-		Short: "A global network of probes to perform network tests such as ping, traceroute, and DNS resolution.",
+		Short: "A global network of probes to perform network tests such as ping, traceroute, and DNS resolution",
 		Long: `The Globalping platform allows anyone to run networking commands such as ping, traceroute, dig, and mtr on probes distributed around the globe.
 The CLI tool provides access to the Globalping API, enabling you to troubleshoot networking issues and script automated tests and benchmarks in a straightforward and user-friendly way.
 For more information about the platform, tips, and best practices, visit our GitHub repository at https://github.com/jsdelivr/globalping.`,
@@ -78,13 +78,12 @@ For more information about the platform, tips, and best practices, visit our Git
 	root.Cmd.SetErr(printer.ErrWriter)
 	// Global flags
 	flags := root.Cmd.PersistentFlags()
-	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `Specify the probe location by providing a comma-separated list of location values, such as continents, regions, countries, US states, cities, or networks.
-	Alternatively, use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from your previous measurements. (default "world")`)
-	flags.IntVarP(&ctx.Limit, "limit", "L", ctx.Limit, "Define the number of probes to use. (default 1)")
-	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "Output results in JSON format. (default false)")
-	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "Disable real-time terminal updates and color, suitable for CI and scripting. (default false)")
-	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "Output only the stats of a measurement; applicable only to dns, http, and ping commands. (default false)")
-	flags.BoolVar(&ctx.Share, "share", ctx.Share, "Print a link at the end of the results to visualize them online. (default false)")
+	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `specify the probe location; provide a comma-separated list of location values, such as continents, regions, countries, US states, cities, or networks or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements`)
+	flags.IntVarP(&ctx.Limit, "limit", "L", ctx.Limit, "define the number of probes to use")
+	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "output results in JSON format (default false)")
+	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "disable real-time terminal updates and color, suitable for CI and scripting (default false)")
+	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "output only the stats of a measurement; applicable only to dns, http, and ping commands (default false)")
+	flags.BoolVar(&ctx.Share, "share", ctx.Share, "print a link at the end of the results to visualize them online (default false)")
 
 	root.Cmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,5 +148,6 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
 
-var helpTemplate = `
-{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+var helpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,23 +68,23 @@ func NewRoot(
 	// rootCmd represents the base command when called without any subcommands
 	root.Cmd = &cobra.Command{
 		Use:   "globalping",
-		Short: "A global network of probes to run network tests like ping, traceroute and DNS resolve.",
-		Long: `Globalping is a platform that allows anyone to run networking commands such as ping, traceroute, dig and mtr on probes distributed all around the world.
-The CLI tool allows you to interact with the API in a simple and human-friendly way to debug networking issues like anycast routing and script automated tests and benchmarks.`,
+		Short: "A global network of probes to perform network tests such as ping, traceroute, and DNS resolution.",
+		Long: `The Globalping platform allows anyone to run networking commands such as ping, traceroute, dig, and mtr on probes distributed around the globe.
+The CLI tool provides access to the Globalping API, enabling you to troubleshoot networking issues and script automated tests and benchmarks in a straightforward and user-friendly way.
+For more information about the platform, tips, and best practices, visit our GitHub repository at https://github.com/jsdelivr/globalping.`,
 	}
 
 	root.Cmd.SetOut(printer.OutWriter)
 	root.Cmd.SetErr(printer.ErrWriter)
 	// Global flags
 	flags := root.Cmd.PersistentFlags()
-	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `Comma-separated list of location values to match against or a measurement ID
-	For example, the partial or full name of a continent, region (e.g eastern europe), country, US state, city or network
-	Or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements.`)
-	flags.IntVarP(&ctx.Limit, "limit", "L", ctx.Limit, "Limit the number of probes to use")
-	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "Output results in JSON format (default false)")
-	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "Disable realtime terminal updates and color suitable for CI and scripting (default false)")
-	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "Output only the stats of a measurement (default false). Only applies to the dns, http and ping commands")
-	flags.BoolVar(&ctx.Share, "share", ctx.Share, "Prints a link at the end the results, allowing to vizualize the results online (default false)")
+	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `Specify the probe location by providing a comma-separated list of location values, such as continents, regions, countries, US states, cities, or networks.
+	Alternatively, use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from your previous measurements. (default "world")`)
+	flags.IntVarP(&ctx.Limit, "limit", "L", ctx.Limit, "Define the number of probes to use. (default 1)")
+	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "Output results in JSON format. (default false)")
+	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "Disable real-time terminal updates and color, suitable for CI and scripting. (default false)")
+	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "Output only the stats of a measurement; applicable only to dns, http, and ping commands. (default false)")
+	flags.BoolVar(&ctx.Share, "share", ctx.Share, "Print a link at the end of the results to visualize them online. (default false)")
 
 	root.Cmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,6 @@ func NewRoot(
 		Use:   "globalping",
 		Short: "A global network of probes to perform network tests such as ping, traceroute, and DNS resolution",
 		Long: `The Globalping platform allows anyone to run networking commands such as ping, traceroute, dig, and mtr on probes distributed around the globe.
-The CLI tool provides access to the Globalping API, enabling you to troubleshoot networking issues and script automated tests and benchmarks in a straightforward and user-friendly way.
 For more information about the platform, tips, and best practices, visit our GitHub repository at https://github.com/jsdelivr/globalping.`,
 	}
 
@@ -85,11 +84,15 @@ For more information about the platform, tips, and best practices, visit our Git
 
 	// Global flags
 	flags := root.Cmd.PersistentFlags()
-	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `specify the probe location; provide a comma-separated list of location values, such as continents, regions, countries, US states, cities, or networks or use [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements`)
+	flags.StringVarP(&ctx.From, "from", "F", ctx.From, `specify the probe locations as a comma-separated list; you may use:
+ - names of continents, regions, countries, US states, cities, or networks
+ - [@1 | first, @2 ... @-2, @-1 | last | previous] to run with the probes from previous measurements in this session
+ - an ID of a previous measurement to run with its probes
+`)
 	flags.IntVarP(&ctx.Limit, "limit", "L", ctx.Limit, "define the number of probes to use")
 	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "output results in JSON format (default false)")
-	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "disable real-time terminal updates and color, suitable for CI and scripting (default false)")
-	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "output only the stats of a measurement; applicable only to dns, http, and ping commands (default false)")
+	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "disable real-time terminal updates and colors, suitable for CI and scripting (default false)")
+	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "output only the latency stats; applicable only to dns, http, and ping commands (default false)")
 	flags.BoolVar(&ctx.Share, "share", ctx.Share, "print a link at the end of the results to visualize them online (default false)")
 
 	root.Cmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,10 +134,16 @@ Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
 
-Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{wrappedFlagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -13,7 +13,7 @@ func (r *Root) initTraceroute() {
 		RunE:    r.RunTraceroute,
 		Use:     "traceroute [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Run a traceroute test.",
+		Short:   "Run a traceroute test",
 		Long: `The traceroute command traces the path packets take to reach a target, displaying each hop along the way, including its round-trip time. Use it to troubleshoot network connectivity issues and identify latency problems.
 
 Examples:
@@ -50,8 +50,8 @@ Examples:
 
 	// traceroute specific flags
 	flags := tracerouteCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use for tracerouting: ICMP, TCP, or UDP. (default \"icmp\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify the port to use for the traceroute. Only applicable for the TCP protocol. (default 80)")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "specify the protocol to use for tracerouting: ICMP, TCP, or UDP (default \"icmp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "specify the port to use for the traceroute; only applicable for the TCP protocol (default 80)")
 
 	r.Cmd.AddCommand(tracerouteCmd)
 }

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -13,42 +13,45 @@ func (r *Root) initTraceroute() {
 		RunE:    r.RunTraceroute,
 		Use:     "traceroute [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Run a traceroute test",
-		Long: `traceroute tracks the route packets take from an IP network on their way to a given host.
+		Short:   "Run a traceroute test.",
+		Long: `The traceroute command traces the path packets take to reach a target, displaying each hop along the way, including its round-trip time. Use it to troubleshoot network connectivity issues and identify latency problems.
 
 Examples:
-  # Traceroute google.com from 2 probes in New York
+  # Traceroute google.com from 2 probes in New York.
   traceroute google.com from New York --limit 2
 
-  # Traceroute google.com using probes from previous measurement
+  # Traceroute google.com using probes from a previous measurement by using its ID.
   traceroute google.com from rvasVvKnj48cxNjC
 
-  # Traceroute google.com using probes from first measurement in session
+  # Traceroute google.com using the same probes from the first measurement in this session.
   traceroute google.com from @1
 
-  # Traceroute google.com using probes from last measurement in session
+  # Traceroute google.com using the same probes from the last measurement in this session.
   traceroute google.com from last
 
-  # Traceroute google.com using probes from second to last measurement in session
+  # Traceroute google.com using the same probes from the second-to-last measurement in this session.
   traceroute google.com from @-2
 
-  # Traceroute 1.1.1.1 from 2 probes from USA or Belgium in CI mode
+  # Traceroute 1.1.1.1 from 2 probes in the USA or Belgium and enable CI mode.
   traceroute 1.1.1.1 from USA,Belgium --limit 2 --ci
 
-  # Traceroute jsdelivr.com from a probe that is from the AWS network and is located in Montreal using the UDP protocol
+  # Traceroute jsdelivr.com from a probe on the AWS network located in Montreal using the UDP protocol.
   traceroute jsdelivr.com from aws+montreal --protocol udp
 
-  # Traceroute jsdelivr.com from a probe that is located in Paris to port 453
+  # Traceroute jsdelivr.com from a probe in Paris using port 453.
   traceroute jsdelivr.com from Paris --port 453
 
-  # Traceroute jsdelivr.com from a probe in ASN 123 with json output
-  traceroute jsdelivr.com from 123 --json`,
+  # Traceroute jsdelivr.com from a probe in ASN 123 and output the results in JSON format.
+  traceroute jsdelivr.com from 123 --json
+  
+  # Traceroute jsdelivr.com from a non-data center probe in Europe and add a link to view the results online.
+  traceroute jsdelivr.com from europe+eyeball --share`,
 	}
 
 	// traceroute specific flags
 	flags := tracerouteCmd.Flags()
-	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specifies the protocol used for tracerouting (ICMP, TCP or UDP) (default \"icmp\")")
-	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specifies the port to use for the traceroute. Only applicable for TCP protocol (default 80)")
+	flags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "Specify the protocol to use for tracerouting: ICMP, TCP, or UDP. (default \"icmp\")")
+	flags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "Specify the port to use for the traceroute. Only applicable for the TCP protocol. (default 80)")
 
 	r.Cmd.AddCommand(tracerouteCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,8 +8,8 @@ import (
 func (r *Root) initVersion() {
 	r.Cmd.AddCommand(&cobra.Command{
 		Run:   r.RunVersion,
-		Use:   "version",
-		Short: "Print the version number of Globalping CLI",
+		Use:   "Display the version number of your installed Globalping CLI.",
+		Short: "Display the version number of your installed Globalping CLI.",
 	})
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ func (r *Root) initVersion() {
 	r.Cmd.AddCommand(&cobra.Command{
 		Run:   r.RunVersion,
 		Use:   "version",
-		Short: "Display the version number of your installed Globalping CLI.",
+		Short: "Display the version number of your installed Globalping CLI",
 	})
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ func (r *Root) initVersion() {
 	r.Cmd.AddCommand(&cobra.Command{
 		Run:   r.RunVersion,
 		Use:   "version",
-		Short: "Display the version number of your installed Globalping CLI",
+		Short: "Display the version of your installed Globalping CLI",
 	})
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 func (r *Root) initVersion() {
 	r.Cmd.AddCommand(&cobra.Command{
 		Run:   r.RunVersion,
-		Use:   "Display the version number of your installed Globalping CLI.",
+		Use:   "version",
 		Short: "Display the version number of your installed Globalping CLI.",
 	})
 }


### PR DESCRIPTION
- revised help screens for `globalping --help` and `globalping [command] --help`
- did not update help text for the `completion` command as it seems to be generated by the used library
