### PR TITLE
misc: fix typos in the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ coverage.html
 
 dist/
 
-# binaries not commited
+# binaries not committed
 bin/

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -95,7 +95,7 @@ func (r *Root) RunPing(cmd *cobra.Command, args []string) error {
 
 func (r *Root) pingInfinite(opts *globalping.MeasurementCreate) error {
 	if r.ctx.Limit > 5 {
-		return fmt.Errorf("continous mode is currently limited to 5 probes")
+		return fmt.Errorf("continuous mode is currently limited to 5 probes")
 	}
 
 	var err error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ The CLI tool allows you to interact with the API in a simple and human-friendly 
 	flags.BoolVarP(&ctx.ToJSON, "json", "J", ctx.ToJSON, "Output results in JSON format (default false)")
 	flags.BoolVarP(&ctx.CIMode, "ci", "C", ctx.CIMode, "Disable realtime terminal updates and color suitable for CI and scripting (default false)")
 	flags.BoolVar(&ctx.ToLatency, "latency", ctx.ToLatency, "Output only the stats of a measurement (default false). Only applies to the dns, http and ping commands")
-	flags.BoolVar(&ctx.Share, "share", ctx.Share, "Prints a link at the end the results, allowing to vizualize the results online (default false)")
+	flags.BoolVar(&ctx.Share, "share", ctx.Share, "Prints a link at the end the results, allowing to visualize the results online (default false)")
 
 	root.Cmd.AddGroup(&cobra.Group{ID: "Measurements", Title: "Measurement Commands:"})
 

--- a/view/infinite.go
+++ b/view/infinite.go
@@ -45,8 +45,8 @@ func (v *viewer) outputStreamingPackets(m *globalping.Measurement) error {
 	probeMeasurement := &m.Results[0]
 	hm := v.ctx.History.Find(m.ID)
 	if probeMeasurement.Result.RawOutput != "" {
-		concurentStats := v.aggregateConcurentStats(v.ctx.AggregatedStats[0], 0, m.ID)
-		parsedOutput := v.parsePingRawOutput(hm, probeMeasurement, concurentStats.Sent)
+		concurrentStats := v.aggregateConcurrentStats(v.ctx.AggregatedStats[0], 0, m.ID)
+		parsedOutput := v.parsePingRawOutput(hm, probeMeasurement, concurrentStats.Sent)
 		if len(hm.Stats) == 0 {
 			hm.Stats = make([]*MeasurementStats, 1)
 		}
@@ -134,7 +134,7 @@ func (v *viewer) generateTable(hm *HistoryItem, m *globalping.Measurement, areaW
 		parsedOutput := v.parsePingRawOutput(hm, probeMeasurement, -1)
 		newAggregatedStats[i] = mergeMeasurementStats(*v.ctx.AggregatedStats[i], parsedOutput.Stats)
 		newStats[i] = parsedOutput.Stats
-		row := getRowValues(v.aggregateConcurentStats(newAggregatedStats[i], i, m.ID))
+		row := getRowValues(v.aggregateConcurrentStats(newAggregatedStats[i], i, m.ID))
 		rowWidth := 0
 		for j := 1; j < len(row); j++ {
 			rowWidth += len(row[j]) + len(colSeparator)
@@ -188,7 +188,7 @@ func (v *viewer) generateTable(hm *HistoryItem, m *globalping.Measurement, areaW
 	return &output, newStats, newAggregatedStats
 }
 
-func (v *viewer) aggregateConcurentStats(completed *MeasurementStats, probeIndex int, excludeId string) *MeasurementStats {
+func (v *viewer) aggregateConcurrentStats(completed *MeasurementStats, probeIndex int, excludeId string) *MeasurementStats {
 	inProgressStats := v.ctx.History.FilterByStatus(globalping.StatusInProgress)
 	for i := range inProgressStats {
 		if inProgressStats[i].Id == excludeId {

--- a/view/infinite_test.go
+++ b/view/infinite_test.go
@@ -268,7 +268,7 @@ Nuremberg, DE, EU, Hetzner Online GmbH (AS0)   |    2 |   0.00% |  4.07 ms |  4.
 	assert.Equal(t, expectedOutput, w.String())
 }
 
-func Test_OutputInfinite_MultipleProbes_MultipleConcurentCalls(t *testing.T) {
+func Test_OutputInfinite_MultipleProbes_MultipleConcurrentCalls(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/view/summary.go
+++ b/view/summary.go
@@ -11,7 +11,7 @@ func (v *viewer) OutputSummary() {
 	}
 
 	if len(v.ctx.AggregatedStats) == 1 {
-		stats := v.aggregateConcurentStats(v.ctx.AggregatedStats[0], 0, "")
+		stats := v.aggregateConcurrentStats(v.ctx.AggregatedStats[0], 0, "")
 
 		v.printer.Printf("\n--- %s ping statistics ---\n", v.ctx.Hostname)
 		v.printer.Printf("%d packets transmitted, %d received, %.2f%% packet loss, time %.0fms\n",


### PR DESCRIPTION
Found via `typos --hidden --format brief`