### PR TITLE
feat: Add support for authorization header

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"github.com/spf13/pflag"
-	"golang.org/x/term"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
 
 	"github.com/jsdelivr/globalping-cli/globalping"
 	"github.com/jsdelivr/globalping-cli/globalping/probe"
@@ -30,13 +31,15 @@ type Root struct {
 func Execute() {
 	utime := utils.NewTime()
 	printer := view.NewPrinter(os.Stdin, os.Stdout, os.Stderr)
+	config := utils.NewConfig()
+	config.Load()
 	ctx := &view.Context{
-		APIMinInterval: globalping.API_MIN_INTERVAL,
+		APIMinInterval: config.GlobalpingAPIInterval,
 		History:        view.NewHistoryBuffer(10),
 		From:           "world",
 		Limit:          1,
 	}
-	globalpingClient := globalping.NewClient(globalping.API_URL)
+	globalpingClient := globalping.NewClient(config)
 	globalpingProbe := probe.NewProbe()
 	viewer := view.NewViewer(ctx, printer, utime, globalpingClient)
 	root := NewRoot(printer, ctx, viewer, utime, globalpingClient, globalpingProbe)

--- a/globalping/client.go
+++ b/globalping/client.go
@@ -3,6 +3,8 @@ package globalping
 import (
 	"net/http"
 	"time"
+
+	"github.com/jsdelivr/globalping-cli/utils"
 )
 
 type Client interface {
@@ -13,18 +15,18 @@ type Client interface {
 
 type client struct {
 	http   *http.Client
-	apiUrl string // The api url endpoint
+	config *utils.Config
 
 	etags        map[string]string // caches Etags by measurement id
 	measurements map[string][]byte // caches Measurements by ETag
 }
 
-func NewClient(url string) Client {
+func NewClient(config *utils.Config) Client {
 	return &client{
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		apiUrl:       url,
+		config:       config,
 		etags:        map[string]string{},
 		measurements: map[string][]byte{},
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.4.0
 	golang.org/x/term v0.18.0
@@ -21,7 +22,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.13 // indirect
 	github.com/tklauser/numcpus v0.7.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/utils/config.go
+++ b/utils/config.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"os"
+	_time "time"
+)
+
+type Config struct {
+	GlobalpingToken       string
+	GlobalpingAPIURL      string
+	GlobalpingAPIInterval _time.Duration
+}
+
+func NewConfig() *Config {
+	return &Config{
+		GlobalpingAPIURL:      "https://api.globalping.io/v1",
+		GlobalpingAPIInterval: 500 * _time.Millisecond,
+	}
+}
+
+func (c *Config) Load() {
+	c.GlobalpingToken = os.Getenv("GLOBALPING_TOKEN")
+}


### PR DESCRIPTION
#42 

`Authorization` header is added when creating a new measurement (POST) if `GLOBALPING_TOKEN` env variable is not empty.