### PR TITLE
misc: improve client caching

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
@@ -39,7 +40,11 @@ func Execute() {
 		From:           "world",
 		Limit:          1,
 	}
-	globalpingClient := globalping.NewClient(config)
+	t := time.NewTicker(10 * time.Second)
+	globalpingClient := globalping.NewClientWithCacheCleanup(globalping.Config{
+		APIURL:   config.GlobalpingAPIURL,
+		APIToken: config.GlobalpingToken,
+	}, t, 30)
 	globalpingProbe := probe.NewProbe()
 	viewer := view.NewViewer(ctx, printer, utime, globalpingClient)
 	root := NewRoot(printer, ctx, viewer, utime, globalpingClient, globalpingProbe)

--- a/globalping/client.go
+++ b/globalping/client.go
@@ -2,9 +2,8 @@ package globalping
 
 import (
 	"net/http"
+	"sync"
 	"time"
-
-	"github.com/jsdelivr/globalping-cli/utils"
 )
 
 type Client interface {
@@ -22,21 +21,103 @@ type Client interface {
 	GetMeasurementRaw(id string) ([]byte, error)
 }
 
-type client struct {
-	http   *http.Client
-	config *utils.Config
-
-	etags        map[string]string // caches Etags by measurement id
-	measurements map[string][]byte // caches Measurements by ETag
+type Config struct {
+	APIURL   string
+	APIToken string
 }
 
-func NewClient(config *utils.Config) Client {
+type CacheEntry struct {
+	ETag     string
+	Data     []byte
+	ExpireAt int64 // Unix timestamp
+}
+
+type client struct {
+	sync.RWMutex
+	http  *http.Client
+	cache map[string]*CacheEntry
+
+	apiURL                        string
+	apiToken                      string
+	apiResponseCacheExpireSeconds int64
+}
+
+// NewClient creates a new client with the given configuration.
+// The client will not have a cache cleanup goroutine, therefore cached responses will never be removed.
+// If you want a cache cleanup goroutine, use NewClientWithCacheCleanup.
+func NewClient(config Config) Client {
 	return &client{
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		config:       config,
-		etags:        map[string]string{},
-		measurements: map[string][]byte{},
+		apiURL:   config.APIURL,
+		apiToken: config.APIToken,
+		cache:    map[string]*CacheEntry{},
+	}
+}
+
+// NewClientWithCacheCleanup creates a new client with a cache cleanup goroutine that runs every t.
+// The cache cleanup goroutine will remove entries that have expired.
+// If cacheExpireSeconds is 0, the cache entries will never expire.
+func NewClientWithCacheCleanup(config Config, t *time.Ticker, cacheExpireSeconds int64) Client {
+	c := NewClient(config).(*client)
+	c.apiResponseCacheExpireSeconds = cacheExpireSeconds
+	go func() {
+		for range t.C {
+			c.cleanupCache()
+		}
+	}()
+	return c
+}
+
+func (c *client) getETag(id string) string {
+	c.RLock()
+	defer c.RUnlock()
+	e, ok := c.cache[id]
+	if !ok {
+		return ""
+	}
+	return e.ETag
+}
+
+func (c *client) getCachedResponse(id string) []byte {
+	c.RLock()
+	defer c.RUnlock()
+	e, ok := c.cache[id]
+	if !ok {
+		return nil
+	}
+	return e.Data
+}
+
+func (c *client) cacheResponse(id string, etag string, resp []byte) {
+	c.Lock()
+	defer c.Unlock()
+	var expires int64
+	if c.apiResponseCacheExpireSeconds != 0 {
+		expires = time.Now().Unix() + c.apiResponseCacheExpireSeconds
+	}
+	e, ok := c.cache[id]
+	if ok {
+		e.ETag = etag
+		e.Data = resp
+		e.ExpireAt = expires
+	} else {
+		c.cache[id] = &CacheEntry{
+			ETag:     etag,
+			Data:     resp,
+			ExpireAt: expires,
+		}
+	}
+}
+
+func (c *client) cleanupCache() {
+	c.Lock()
+	defer c.Unlock()
+	now := time.Now().Unix()
+	for k, v := range c.cache {
+		if v.ExpireAt > 0 && v.ExpireAt < now {
+			delete(c.cache, k)
+		}
 	}
 }

--- a/globalping/globalping.go
+++ b/globalping/globalping.go
@@ -26,7 +26,7 @@ func (c *client) CreateMeasurement(measurement *MeasurementCreate) (*Measurement
 		return nil, &MeasurementError{Message: "failed to marshal post data - please report this bug"}
 	}
 
-	req, err := http.NewRequest("POST", c.config.GlobalpingAPIURL+"/measurements", bytes.NewBuffer(postData))
+	req, err := http.NewRequest("POST", c.apiURL+"/measurements", bytes.NewBuffer(postData))
 	if err != nil {
 		return nil, &MeasurementError{Message: "failed to create request - please report this bug"}
 	}
@@ -34,8 +34,8 @@ func (c *client) CreateMeasurement(measurement *MeasurementCreate) (*Measurement
 	req.Header.Set("Accept-Encoding", "br")
 	req.Header.Set("Content-Type", "application/json")
 
-	if c.config.GlobalpingToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.config.GlobalpingToken)
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
 	}
 
 	resp, err := c.http.Do(req)
@@ -83,7 +83,7 @@ func (c *client) CreateMeasurement(measurement *MeasurementCreate) (*Measurement
 			creditsRequired, _ := strconv.ParseInt(resp.Header.Get("X-Credits-Required"), 10, 64)
 			remaining := rateLimitRemaining + creditsRemaining
 			required := rateLimitRemaining + creditsRequired
-			if c.config.GlobalpingToken == "" {
+			if c.apiToken == "" {
 				if remaining > 0 {
 					err.Message = fmt.Sprintf(moreCreditsRequiredNoAuthErr, utils.Pluralize(remaining, "credit"), required, utils.FormatSeconds(rateLimitReset))
 					return nil, err
@@ -142,7 +142,7 @@ func (c *client) GetMeasurement(id string) (*Measurement, error) {
 }
 
 func (c *client) GetMeasurementRaw(id string) ([]byte, error) {
-	req, err := http.NewRequest("GET", c.config.GlobalpingAPIURL+"/measurements/"+id, nil)
+	req, err := http.NewRequest("GET", c.apiURL+"/measurements/"+id, nil)
 	if err != nil {
 		return nil, &MeasurementError{Message: "failed to create request"}
 	}
@@ -150,7 +150,7 @@ func (c *client) GetMeasurementRaw(id string) ([]byte, error) {
 	req.Header.Set("User-Agent", userAgent())
 	req.Header.Set("Accept-Encoding", "br")
 
-	etag := c.etags[id]
+	etag := c.getETag(id)
 	if etag != "" {
 		req.Header.Set("If-None-Match", etag)
 	}
@@ -179,7 +179,7 @@ func (c *client) GetMeasurementRaw(id string) ([]byte, error) {
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		respBytes := c.measurements[etag]
+		respBytes := c.getCachedResponse(id)
 		if respBytes == nil {
 			return nil, &MeasurementError{Message: "response not found in etags cache"}
 		}
@@ -199,9 +199,7 @@ func (c *client) GetMeasurementRaw(id string) ([]byte, error) {
 	}
 
 	// save etag and response to cache
-	etag = resp.Header.Get("ETag")
-	c.etags[id] = etag
-	c.measurements[etag] = respBytes
+	c.cacheResponse(id, resp.Header.Get("ETag"), respBytes)
 
 	return respBytes, nil
 }

--- a/globalping/globalping_test.go
+++ b/globalping/globalping_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/andybalholm/brotli"
-	"github.com/jsdelivr/globalping-cli/utils"
 	"github.com/jsdelivr/globalping-cli/version"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +41,7 @@ func TestPostAPI(t *testing.T) {
 func testPostValid(t *testing.T) {
 	server := generateServer(`{"id":"abcd","probesCount":1}`, http.StatusAccepted)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	opts := &MeasurementCreate{}
 	res, err := client.CreateMeasurement(opts)
@@ -55,9 +54,9 @@ func testPostValid(t *testing.T) {
 func testPostAuthorized(t *testing.T) {
 	server := generateServerAuthorized(`{"id":"abcd","probesCount":1}`)
 	defer server.Close()
-	client := NewClient(&utils.Config{
-		GlobalpingToken:  "secret",
-		GlobalpingAPIURL: server.URL,
+	client := NewClient(Config{
+		APIToken: "secret",
+		APIURL:   server.URL,
 	})
 
 	opts := &MeasurementCreate{}
@@ -71,8 +70,8 @@ func testPostAuthorized(t *testing.T) {
 func testPostAuthorizedError(t *testing.T) {
 	server := generateServerAuthorized(`{"id":"abcd","probesCount":1}`)
 	defer server.Close()
-	client := NewClient(&utils.Config{
-		GlobalpingAPIURL: server.URL,
+	client := NewClient(Config{
+		APIURL: server.URL,
 	})
 
 	opts := &MeasurementCreate{}
@@ -101,7 +100,7 @@ func testPostMoreCreditsRequiredNoAuthError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 	opts := &MeasurementCreate{}
 	_, err := client.CreateMeasurement(opts)
 	assert.EqualError(t, err, fmt.Sprintf(moreCreditsRequiredNoAuthErr, "2 credits", 3, "1 minute"))
@@ -130,9 +129,9 @@ func testPostMoreCreditsRequiredAuthError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(&utils.Config{
-		GlobalpingToken:  "secret",
-		GlobalpingAPIURL: server.URL,
+	client := NewClient(Config{
+		APIToken: "secret",
+		APIURL:   server.URL,
 	})
 	opts := &MeasurementCreate{}
 
@@ -161,7 +160,7 @@ func testPostNoCreditsNoAuthError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 	opts := &MeasurementCreate{}
 	_, err := client.CreateMeasurement(opts)
 
@@ -185,9 +184,9 @@ func testPostNoCreditsAuthError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(&utils.Config{
-		GlobalpingToken:  "secret",
-		GlobalpingAPIURL: server.URL,
+	client := NewClient(Config{
+		APIToken: "secret",
+		APIURL:   server.URL,
 	})
 	opts := &MeasurementCreate{}
 	_, err := client.CreateMeasurement(opts)
@@ -203,7 +202,7 @@ func testPostNoProbes(t *testing.T) {
     }}`, 422)
 	defer server.Close()
 
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 	opts := &MeasurementCreate{}
 	_, err := client.CreateMeasurement(opts)
 
@@ -223,7 +222,7 @@ func testPostValidation(t *testing.T) {
         }
     }}`, 400)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	opts := &MeasurementCreate{}
 	_, err := client.CreateMeasurement(opts)
@@ -242,7 +241,7 @@ func testPostInternalError(t *testing.T) {
       "type": "api_error"
     }}`, 500)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	opts := &MeasurementCreate{}
 	_, err := client.CreateMeasurement(opts)
@@ -269,7 +268,7 @@ func TestGetAPI(t *testing.T) {
 func testGetValid(t *testing.T) {
 	server := generateServer(`{"id":"abcd"}`, http.StatusOK)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 	res, err := client.GetMeasurement("abcd")
 	if err != nil {
 		t.Error(err)
@@ -280,7 +279,7 @@ func testGetValid(t *testing.T) {
 func testGetJson(t *testing.T) {
 	server := generateServer(`{"id":"abcd"}`, http.StatusOK)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 	res, err := client.GetMeasurementRaw("abcd")
 	if err != nil {
 		t.Error(err)
@@ -333,7 +332,7 @@ func testGetPing(t *testing.T) {
 		}
 	}]}`, http.StatusOK)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	res, err := client.GetMeasurement("abcd")
 	if err != nil {
@@ -429,7 +428,7 @@ func testGetTraceroute(t *testing.T) {
 	}}]}`, http.StatusOK)
 	defer server.Close()
 
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	res, err := client.GetMeasurement("abcd")
 	if err != nil {
@@ -505,7 +504,7 @@ func testGetDns(t *testing.T) {
 		}
 	}]}`, http.StatusOK)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	res, err := client.GetMeasurement("abcd")
 	if err != nil {
@@ -627,7 +626,7 @@ func testGetMtr(t *testing.T) {
 		}
 	}]}`, http.StatusOK)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	res, err := client.GetMeasurement("abcd")
 	if err != nil {
@@ -732,7 +731,7 @@ func testGetHttp(t *testing.T) {
 		}
 	}]}`, http.StatusOK)
 	defer server.Close()
-	client := NewClient(&utils.Config{GlobalpingAPIURL: server.URL})
+	client := NewClient(Config{APIURL: server.URL})
 
 	res, err := client.GetMeasurement("abcd")
 	if err != nil {
@@ -806,7 +805,7 @@ func TestFetchWithEtag(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 
-	client := NewClient(&utils.Config{GlobalpingAPIURL: s.URL})
+	client := NewClient(Config{APIURL: s.URL})
 
 	// first request for id1
 	m, err := client.GetMeasurement(id1)
@@ -852,7 +851,7 @@ func TestFetchWithBrotli(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 
-	client := NewClient(&utils.Config{GlobalpingAPIURL: s.URL})
+	client := NewClient(Config{APIURL: s.URL})
 
 	m, err := client.GetMeasurement(id)
 	assert.NoError(t, err)


### PR DESCRIPTION
This allows for safely getting and setting cached responses in memory from the client.
Also, it adds a cleanup function and a goroutine that will periodically remove the expired cached responses to free up the memory for long running commands.