### PR TITLE
fix: output extra information into stderr

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -123,7 +123,7 @@ func (r *Root) pingInfinite(opts *globalping.MeasurementCreate) error {
 		e, ok := err.(*globalping.MeasurementError)
 		if ok && e.Code == http.StatusTooManyRequests {
 			r.Cmd.SilenceErrors = true
-			r.printer.Printf(r.printer.Color("> "+e.Message, view.FGBrightYellow) + "\n")
+			r.printer.ErrPrintf(r.printer.Color("> "+e.Message, view.FGBrightYellow) + "\n")
 		}
 	}
 	r.viewer.OutputShare()
@@ -211,7 +211,7 @@ func (r *Root) createMeasurement(opts *globalping.MeasurementCreate) (*view.Hist
 		r.ctx.RecordToSession = false
 		err := saveIdToSession(res.ID)
 		if err != nil {
-			r.printer.Printf("Warning: %s\n", err)
+			r.printer.ErrPrintf("Warning: %s\n", err)
 		}
 	}
 	return hm, nil

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -516,14 +516,16 @@ func Test_Execute_Ping_Infinite_Output_TooManyRequests_Error(t *testing.T) {
 	timeMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	w := new(bytes.Buffer)
-	printer := view.NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := view.NewPrinter(nil, w, errW)
 	ctx := createDefaultContext("ping")
 	root := NewRoot(printer, ctx, viewerMock, timeMock, gbMock, nil)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "Berlin", "--infinite", "--share"}
 	err := root.Cmd.ExecuteContext(context.TODO())
 	assert.Equal(t, "too many requests", err.Error())
 
-	assert.Equal(t, "> too many requests\n", w.String())
+	assert.Equal(t, "> too many requests\n", errW.String())
+	assert.Equal(t, "", w.String())
 
 	expectedCtx := createDefaultExpectedContext("ping")
 	expectedCtx.History.Find(measurementID1).Status = globalping.StatusFinished

--- a/view/default.go
+++ b/view/default.go
@@ -15,17 +15,27 @@ func (v *viewer) outputDefault(id string, data *globalping.Measurement, m *globa
 			v.printer.Println()
 		}
 
-		// Output slightly different format if state is available
-		v.printer.Println(v.getProbeInfo(result))
+		v.printer.ErrPrintln(v.getProbeInfo(result))
 
-		if v.isBodyOnlyHttpGet(m) {
-			v.printer.Println(strings.TrimSpace(result.Result.RawBody))
+		if v.ctx.Cmd == "http" {
+			if v.ctx.Full {
+				firstLineEnd := strings.Index(result.Result.RawOutput, "\n")
+				if firstLineEnd > 0 {
+					v.printer.ErrPrintln(result.Result.RawOutput[:firstLineEnd])
+				}
+				v.printer.ErrPrintln(result.Result.RawHeaders)
+				v.printer.Println(strings.TrimSpace(result.Result.RawBody))
+			} else if m.Options.Request.Method == "GET" {
+				v.printer.Println(strings.TrimSpace(result.Result.RawBody))
+			} else {
+				v.printer.Println(strings.TrimSpace(result.Result.RawOutput))
+			}
 		} else {
 			v.printer.Println(strings.TrimSpace(result.Result.RawOutput))
 		}
 	}
 
 	if v.ctx.Share {
-		v.printer.Println(v.getShareMessage(id))
+		v.printer.ErrPrintln(v.getShareMessage(id))
 	}
 }

--- a/view/default_test.go
+++ b/view/default_test.go
@@ -129,7 +129,8 @@ func Test_Output_Default_HTTP_Get_Share(t *testing.T) {
 		},
 	}
 	w := new(bytes.Buffer)
-	printer := NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := NewPrinter(nil, w, errW)
 	printer.DisableStyling()
 	viewer := NewViewer(&Context{
 		Cmd:    "http",
@@ -140,12 +141,14 @@ func Test_Output_Default_HTTP_Get_Share(t *testing.T) {
 	viewer.Output(measurementID1, m)
 
 	assert.Equal(t, fmt.Sprintf(`> Berlin, DE, EU, Network 1 (AS123)
-Body 1
-
 > New York (NY), US, NA, Network 2 (AS567)
-Body 2
 > View the results online: https://www.jsdelivr.com/globalping?measurement=%s
-`, measurementID1), w.String())
+`, measurementID1), errW.String())
+
+	assert.Equal(t, `Body 1
+
+Body 2
+`, w.String())
 }
 
 func Test_Output_Default_HTTP_Get_Full(t *testing.T) {
@@ -163,7 +166,7 @@ func Test_Output_Default_HTTP_Get_Full(t *testing.T) {
 					Network:   "Network 1",
 				},
 				Result: globalping.ProbeResult{
-					RawOutput:  "Headers 1\nBody 1",
+					RawOutput:  "HTTP/1.1 301\nHeaders 1\nBody 1",
 					RawHeaders: "Headers 1",
 					RawBody:    "Body 1",
 				},
@@ -178,7 +181,7 @@ func Test_Output_Default_HTTP_Get_Full(t *testing.T) {
 					Network:   "Network 2",
 				},
 				Result: globalping.ProbeResult{
-					RawOutput:  "Headers 2\nBody 2",
+					RawOutput:  "HTTP/1.1 301\nHeaders 2\nBody 2",
 					RawHeaders: "Headers 2",
 					RawBody:    "Body 2",
 				},
@@ -197,7 +200,8 @@ func Test_Output_Default_HTTP_Get_Full(t *testing.T) {
 		},
 	}
 	w := new(bytes.Buffer)
-	printer := NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := NewPrinter(nil, w, errW)
 	printer.DisableStyling()
 	viewer := NewViewer(&Context{
 		Cmd:    "http",
@@ -208,11 +212,14 @@ func Test_Output_Default_HTTP_Get_Full(t *testing.T) {
 	viewer.Output(measurementID1, m)
 
 	assert.Equal(t, `> Berlin, DE, EU, Network 1 (AS123)
+HTTP/1.1 301
 Headers 1
-Body 1
-
 > New York (NY), US, NA, Network 2 (AS567)
+HTTP/1.1 301
 Headers 2
+`, errW.String())
+	assert.Equal(t, `Body 1
+
 Body 2
 `, w.String())
 }
@@ -265,7 +272,8 @@ func Test_Output_Default_HTTP_Head(t *testing.T) {
 		},
 	}
 	w := new(bytes.Buffer)
-	printer := NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := NewPrinter(nil, w, errW)
 	printer.DisableStyling()
 	viewer := NewViewer(&Context{
 		Cmd:    "http",
@@ -275,9 +283,10 @@ func Test_Output_Default_HTTP_Head(t *testing.T) {
 	viewer.Output(measurementID1, m)
 
 	assert.Equal(t, `> Berlin, DE, EU, Network 1 (AS123)
-Headers 1
-
 > New York (NY), US, NA, Network 2 (AS567)
+`, errW.String())
+	assert.Equal(t, `Headers 1
+
 Headers 2
 `, w.String())
 }
@@ -322,7 +331,8 @@ func Test_Output_Default_Ping(t *testing.T) {
 
 	m := &globalping.MeasurementCreate{}
 	w := new(bytes.Buffer)
-	printer := NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := NewPrinter(nil, w, errW)
 	printer.DisableStyling()
 	viewer := NewViewer(&Context{
 		Cmd:    "ping",
@@ -332,9 +342,10 @@ func Test_Output_Default_Ping(t *testing.T) {
 	viewer.Output(measurementID1, m)
 
 	assert.Equal(t, `> Berlin, DE, EU, Network 1 (AS123)
-Ping Results 1
-
 > New York (NY), US, NA, Network 2 (AS567)
+`, errW.String())
+	assert.Equal(t, `Ping Results 1
+
 Ping Results 2
 `, w.String())
 }

--- a/view/infinite.go
+++ b/view/infinite.go
@@ -47,7 +47,7 @@ func (v *viewer) OutputInfinite(m *globalping.Measurement) error {
 func (v *viewer) outputStreamingPackets(m *globalping.Measurement) error {
 	if len(v.ctx.AggregatedStats) == 0 {
 		v.ctx.AggregatedStats = []*MeasurementStats{NewMeasurementStats()}
-		v.printer.Print(v.getAPICreditInfo())
+		v.printer.ErrPrint(v.getAPICreditInfo())
 	}
 	probeMeasurement := &m.Results[0]
 	hm := v.ctx.History.Find(m.ID)
@@ -60,7 +60,7 @@ func (v *viewer) outputStreamingPackets(m *globalping.Measurement) error {
 		hm.Stats[0] = parsedOutput.Stats
 		if !v.ctx.IsHeaderPrinted {
 			v.ctx.Hostname = parsedOutput.Hostname
-			v.printer.Println(v.getProbeInfo(probeMeasurement))
+			v.printer.ErrPrintln(v.getProbeInfo(probeMeasurement))
 			v.printer.Printf("PING %s (%s) %s bytes of data.\n",
 				parsedOutput.Hostname,
 				parsedOutput.Address,
@@ -101,7 +101,7 @@ func (v *viewer) outputTableView(m *globalping.Measurement) error {
 
 func (v *viewer) outputFailSummary(m *globalping.Measurement) error {
 	for i := range m.Results {
-		v.printer.Println(v.getProbeInfo(&m.Results[i]))
+		v.printer.ErrPrintln(v.getProbeInfo(&m.Results[i]))
 		v.printer.Println(m.Results[i].Result.RawOutput)
 	}
 	return errors.New("all probes failed")

--- a/view/infinite_test.go
+++ b/view/infinite_test.go
@@ -22,7 +22,8 @@ func Test_OutputInfinite_SingleProbe_InProgress(t *testing.T) {
 	ctx := createDefaultContext("ping")
 	hm := ctx.History.Find(measurementID1)
 	w := new(bytes.Buffer)
-	printer := NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := NewPrinter(nil, w, errW)
 	printer.DisableStyling()
 	viewer := NewViewer(ctx, printer, timeMock, nil)
 
@@ -34,10 +35,9 @@ func Test_OutputInfinite_SingleProbe_InProgress(t *testing.T) {
 	err := viewer.OutputInfinite(measurement)
 	assert.NoError(t, err)
 
-	assert.Equal(t,
-		apiCreditInfo+
-			`> Berlin, DE, EU, Deutsche Telekom AG (AS3320)
-PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
+	assert.Equal(t, apiCreditInfo+
+		"> Berlin, DE, EU, Deutsche Telekom AG (AS3320)\n", errW.String())
+	assert.Equal(t, `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 `,
 		w.String(),
 	)
@@ -48,10 +48,9 @@ PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 	err = viewer.OutputInfinite(measurement)
 	assert.NoError(t, err)
 
-	assert.Equal(t,
-		apiCreditInfo+
-			`> Berlin, DE, EU, Deutsche Telekom AG (AS3320)
-PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
+	assert.Equal(t, apiCreditInfo+
+		"> Berlin, DE, EU, Deutsche Telekom AG (AS3320)\n", errW.String())
+	assert.Equal(t, `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=56 time=12.9 ms
 `,
 		w.String(),
@@ -64,10 +63,9 @@ PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 	err = viewer.OutputInfinite(measurement)
 	assert.NoError(t, err)
 
-	assert.Equal(t,
-		apiCreditInfo+
-			`> Berlin, DE, EU, Deutsche Telekom AG (AS3320)
-PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
+	assert.Equal(t, apiCreditInfo+
+		"> Berlin, DE, EU, Deutsche Telekom AG (AS3320)\n", errW.String())
+	assert.Equal(t, `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=56 time=12.9 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=56 time=12.7 ms
 `,
@@ -92,10 +90,9 @@ rtt min/avg/max/mdev = 12.711/12.854/12.952/0.103 ms`
 	err = viewer.OutputInfinite(measurement)
 	assert.NoError(t, err)
 
-	assert.Equal(t,
-		apiCreditInfo+
-			`> Berlin, DE, EU, Deutsche Telekom AG (AS3320)
-PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
+	assert.Equal(t, apiCreditInfo+
+		"> Berlin, DE, EU, Deutsche Telekom AG (AS3320)\n", errW.String())
+	assert.Equal(t, `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=56 time=12.9 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=56 time=12.7 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=3 ttl=56 time=13.0 ms
@@ -116,10 +113,10 @@ PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 	err = viewer.OutputInfinite(measurement)
 	assert.NoError(t, err)
 
+	assert.Equal(t, apiCreditInfo+
+		"> Berlin, DE, EU, Deutsche Telekom AG (AS3320)\n", errW.String())
 	assert.Equal(t,
-		apiCreditInfo+
-			`> Berlin, DE, EU, Deutsche Telekom AG (AS3320)
-PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
+		`PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=56 time=12.9 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=56 time=12.7 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=3 ttl=56 time=13.0 ms

--- a/view/json.go
+++ b/view/json.go
@@ -9,7 +9,7 @@ func (v *viewer) OutputJson(id string) error {
 	v.printer.Println(string(output))
 
 	if v.ctx.Share {
-		v.printer.Println(v.getShareMessage(id))
+		v.printer.ErrPrintln(v.getShareMessage(id))
 	}
 	v.printer.Println()
 

--- a/view/latency.go
+++ b/view/latency.go
@@ -16,7 +16,7 @@ func (v *viewer) OutputLatency(id string, data *globalping.Measurement) error {
 			v.printer.Println()
 		}
 
-		v.printer.Println(v.getProbeInfo(&result))
+		v.printer.ErrPrintln(v.getProbeInfo(&result))
 
 		switch v.ctx.Cmd {
 		case "ping":
@@ -50,7 +50,7 @@ func (v *viewer) OutputLatency(id string, data *globalping.Measurement) error {
 	}
 
 	if v.ctx.Share {
-		v.printer.Println(v.getShareMessage(id))
+		v.printer.ErrPrintln(v.getShareMessage(id))
 	}
 	v.printer.Println()
 

--- a/view/latency_test.go
+++ b/view/latency_test.go
@@ -52,12 +52,13 @@ func Test_Output_Latency_Ping(t *testing.T) {
 	gbMock.EXPECT().GetMeasurement(measurementID1).Times(1).Return(measurement, nil)
 
 	w := new(bytes.Buffer)
+	errW := new(bytes.Buffer)
 	viewer := NewViewer(
 		&Context{
 			Cmd:       "ping",
 			ToLatency: true,
 		},
-		NewPrinter(nil, w, w),
+		NewPrinter(nil, w, errW),
 		nil,
 		gbMock,
 	)
@@ -66,10 +67,10 @@ func Test_Output_Latency_Ping(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "\033[1;38;5;43m> City (State), Country, Continent, Network (AS12345) (tag-1)\033[0m\n"+
-		"\033[1mMin: \033[0m8.00 ms\n"+
+		"\033[1;38;5;43m> City B (State B), Country B, Continent B, Network B (AS12349)\033[0m\n", errW.String())
+	assert.Equal(t, "\033[1mMin: \033[0m8.00 ms\n"+
 		"\033[1mMax: \033[0m20.00 ms\n"+
 		"\033[1mAvg: \033[0m12.00 ms\n\n"+
-		"\033[1;38;5;43m> City B (State B), Country B, Continent B, Network B (AS12349)\033[0m\n"+
 		"\033[1mMin: \033[0m9.00 ms\n"+
 		"\033[1mMax: \033[0m22.00 ms\n"+
 		"\033[1mAvg: \033[0m15.00 ms\n\n", w.String())
@@ -293,7 +294,8 @@ func Test_Output_Latency_Http_StylingDisabled(t *testing.T) {
 	gbMock.EXPECT().GetMeasurement(measurementID1).Times(1).Return(measurement, nil)
 
 	w := new(bytes.Buffer)
-	printer := NewPrinter(nil, w, w)
+	errW := new(bytes.Buffer)
+	printer := NewPrinter(nil, w, errW)
 	printer.DisableStyling()
 	viewer := NewViewer(
 		&Context{
@@ -309,7 +311,8 @@ func Test_Output_Latency_Http_StylingDisabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, `> City (State), Country, Continent, Network (AS12345)
-Total: 44 ms
+`, errW.String())
+	assert.Equal(t, `Total: 44 ms
 Download: 11 ms
 First byte: 20 ms
 DNS: 5 ms

--- a/view/printer.go
+++ b/view/printer.go
@@ -81,6 +81,18 @@ func (p *Printer) Printf(format string, a ...any) {
 	fmt.Fprintf(p.OutWriter, format, a...)
 }
 
+func (p *Printer) ErrPrint(a ...any) {
+	fmt.Fprint(p.ErrWriter, a...)
+}
+
+func (p *Printer) ErrPrintln(a ...any) {
+	fmt.Fprintln(p.ErrWriter, a...)
+}
+
+func (p *Printer) ErrPrintf(format string, a ...any) {
+	fmt.Fprintf(p.ErrWriter, format, a...)
+}
+
 func (p *Printer) FillLeft(s string, w int) string {
 	if len(s) >= w {
 		return s

--- a/view/share.go
+++ b/view/share.go
@@ -9,14 +9,14 @@ func (v *viewer) OutputShare() {
 	}
 
 	if len(v.ctx.AggregatedStats) > 1 {
-		v.printer.Println() // Add a newline in table view
+		v.printer.ErrPrintln() // Add a newline in table view
 	}
 	ids := v.ctx.History.ToString(".")
 	if ids != "" {
-		v.printer.Println(v.getShareMessage(ids))
+		v.printer.ErrPrintln(v.getShareMessage(ids))
 	}
 	if v.ctx.MeasurementsCreated > v.ctx.History.Capacity() {
-		v.printer.Printf("For long-running continuous mode measurements, only the last %d packets are shared.\n",
+		v.printer.ErrPrintf("For long-running continuous mode measurements, only the last %d packets are shared.\n",
 			v.ctx.Packets*v.ctx.History.Capacity())
 	}
 }

--- a/view/share_test.go
+++ b/view/share_test.go
@@ -11,18 +11,19 @@ import (
 
 func Test_OutputShare(t *testing.T) {
 	t.Run("Single_location", func(t *testing.T) {
-		w := new(bytes.Buffer)
 		ctx := createDefaultContext("ping")
 		ctx.AggregatedStats = []*MeasurementStats{
 			{Sent: 1, Rcv: 0, Lost: 1, Loss: 100, Last: -1, Min: math.MaxFloat64, Avg: -1, Max: -1, Time: 0},
 		}
 		ctx.Share = true
-		viewer := NewViewer(ctx, NewPrinter(nil, w, w), nil, nil)
+		w := new(bytes.Buffer)
+		errw := new(bytes.Buffer)
+		viewer := NewViewer(ctx, NewPrinter(nil, w, errw), nil, nil)
 		viewer.OutputShare()
 
+		assert.Equal(t, "", w.String())
 		expectedOutput := fmt.Sprintf("\033[1;38;5;43m> View the results online: https://www.jsdelivr.com/globalping?measurement=%s\033[0m\n", measurementID1)
-
-		assert.Equal(t, expectedOutput, w.String())
+		assert.Equal(t, expectedOutput, errw.String())
 	})
 
 	t.Run("Multiple_locations", func(t *testing.T) {
@@ -34,13 +35,15 @@ func Test_OutputShare(t *testing.T) {
 		ctx.History.Push(&HistoryItem{Id: measurementID2})
 		ctx.Share = true
 		w := new(bytes.Buffer)
-		printer := NewPrinter(nil, w, w)
+		errw := new(bytes.Buffer)
+		printer := NewPrinter(nil, w, errw)
 		printer.DisableStyling()
 		viewer := NewViewer(ctx, printer, nil, nil)
 		viewer.OutputShare()
 
+		assert.Equal(t, "", w.String())
 		expectedOutput := fmt.Sprintf("\n> View the results online: https://www.jsdelivr.com/globalping?measurement=%s.%s\n", measurementID1, measurementID2)
-		assert.Equal(t, expectedOutput, w.String())
+		assert.Equal(t, expectedOutput, errw.String())
 	})
 
 	t.Run("Multiple_locations_More_calls_than_MaxHistory", func(t *testing.T) {
@@ -57,13 +60,15 @@ func Test_OutputShare(t *testing.T) {
 			Packets:             16,
 		}
 		w := new(bytes.Buffer)
-		printer := NewPrinter(nil, w, w)
+		errw := new(bytes.Buffer)
+		printer := NewPrinter(nil, w, errw)
 		printer.DisableStyling()
 		viewer := NewViewer(ctx, printer, nil, nil)
 		viewer.OutputShare()
 
+		assert.Equal(t, "", w.String())
 		expectedOutput := fmt.Sprintf("\n> View the results online: https://www.jsdelivr.com/globalping?measurement=%s", measurementID2) +
 			"\nFor long-running continuous mode measurements, only the last 16 packets are shared.\n"
-		assert.Equal(t, expectedOutput, w.String())
+		assert.Equal(t, expectedOutput, errw.String())
 	})
 }


### PR DESCRIPTION
The following text will go to `stderr` instead of `stdout`:
 - all lines starting with `>` (location info, share links, ...)
 - `This infinite ping will consume 1 API credit for every 16 packets until stopped.` message from https://github.com/jsdelivr/globalping-cli/pull/114
 - The initial line + all headers of http --full command (as in https://github.com/jsdelivr/globalping-cli/issues/55)
