### PR TITLE
feat: add limits command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Additional Commands:
   help          Help about any command
   history       Display the measurement history of your current session
   install-probe Join the Globalping network by running a probe
+  limits        Show the current rate limits
   version       Display the version of your installed Globalping CLI
 
 Flags:

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -30,7 +30,6 @@ func (r *Root) RunLimits(cmd *cobra.Command, args []string) error {
 	createLimit := utils.Pluralize(limits.RateLimits.Measurements.Create.Limit, "test")
 	createConsumed := limits.RateLimits.Measurements.Create.Limit - limits.RateLimits.Measurements.Create.Remaining
 	createRemaining := limits.RateLimits.Measurements.Create.Remaining
-	createResets := utils.FormatSeconds(limits.RateLimits.Measurements.Create.Reset)
 	t := limits.RateLimits.Measurements.Create.Type
 	if t == globalping.CreateLimitTypeUser {
 		r.printer.Printf("Authentication: token (%s)\n\n", username)
@@ -40,13 +39,15 @@ func (r *Root) RunLimits(cmd *cobra.Command, args []string) error {
 	r.printer.Printf(`Creating measurements: 
  - %s per hour
  - %d consumed, %d remaining
- - resets in %s
 `,
 		createLimit,
 		createConsumed,
 		createRemaining,
-		createResets,
 	)
+	if limits.RateLimits.Measurements.Create.Reset > 0 {
+		createResets := utils.FormatSeconds(limits.RateLimits.Measurements.Create.Reset)
+		r.printer.Printf(" - resets in %s\n", createResets)
+	}
 	if t == globalping.CreateLimitTypeUser {
 		credits := utils.Pluralize(limits.Credits.Remaining, "credit")
 		r.printer.Printf(`

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func (r *Root) initLimits() {
+	limitsCmd := &cobra.Command{
+		Use:   "limits",
+		Short: "Show the current rate limits",
+		Long:  `Show the current rate limits.`,
+		RunE:  r.RunLimits,
+	}
+
+	r.Cmd.AddCommand(limitsCmd)
+}
+
+func (r *Root) RunLimits(cmd *cobra.Command, args []string) error {
+	introspection, _ := r.client.TokenIntrospection("")
+	username := ""
+	if introspection != nil {
+		username = introspection.Username
+	}
+	limits, err := r.client.Limits()
+	if err != nil {
+		return err
+	}
+	createLimit := utils.Pluralize(limits.RateLimits.Measurements.Create.Limit, "test")
+	createConsumed := limits.RateLimits.Measurements.Create.Limit - limits.RateLimits.Measurements.Create.Remaining
+	createRemaining := limits.RateLimits.Measurements.Create.Remaining
+	createResets := utils.FormatSeconds(limits.RateLimits.Measurements.Create.Reset)
+	t := limits.RateLimits.Measurements.Create.Type
+	if t == globalping.CreateLimitTypeUser {
+		r.printer.Printf("Authentication: token (%s)\n\n", username)
+	} else {
+		r.printer.Printf("Authentication: IP address\n\n")
+	}
+	r.printer.Printf(`Creating measurements: 
+ - %s per hour
+ - %d consumed, %d remaining
+ - resets in %s
+`,
+		createLimit,
+		createConsumed,
+		createRemaining,
+		createResets,
+	)
+	if t == globalping.CreateLimitTypeUser {
+		credits := utils.Pluralize(limits.Credits.Remaining, "credit")
+		r.printer.Printf(`
+Credits:
+ - %s remaining (may be used to create measurements above the hourly limits)
+`, credits)
+	}
+	return nil
+}

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jsdelivr/globalping-cli/globalping"
+	"github.com/jsdelivr/globalping-cli/mocks"
+	"github.com/jsdelivr/globalping-cli/view"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_Limits_User(t *testing.T) {
+	t.Cleanup(sessionCleanup)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	gbMock := mocks.NewMockClient(ctrl)
+
+	gbMock.EXPECT().TokenIntrospection("").Return(&globalping.IntrospectionResponse{
+		Active:   true,
+		Username: "test",
+	}, nil)
+	gbMock.EXPECT().Limits().Return(&globalping.LimitsResponse{
+		RateLimits: globalping.RateLimits{
+			Measurements: globalping.MeasurementsLimits{
+				Create: globalping.MeasurementsCreateLimits{
+					Type:      "user",
+					Limit:     500,
+					Remaining: 350,
+					Reset:     600,
+				},
+			},
+		},
+		Credits: globalping.CreditLimits{
+			Remaining: 1000,
+		},
+	}, nil)
+
+	w := new(bytes.Buffer)
+	r := new(bytes.Buffer)
+	printer := view.NewPrinter(r, w, w)
+	ctx := createDefaultContext("")
+
+	root := NewRoot(printer, ctx, nil, nil, gbMock, nil, nil)
+
+	os.Args = []string{"globalping", "limits"}
+	err := root.Cmd.ExecuteContext(context.TODO())
+	assert.NoError(t, err)
+
+	assert.Equal(t, `Authentication: token (test)
+
+Creating measurements: 
+ - 500 tests per hour
+ - 150 consumed, 350 remaining
+ - resets in 10 minutes
+
+Credits:
+ - 1000 credits remaining (may be used to create measurements above the hourly limits)
+`, w.String())
+}
+
+func Test_Limits_IP(t *testing.T) {
+	t.Cleanup(sessionCleanup)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	gbMock := mocks.NewMockClient(ctrl)
+
+	gbMock.EXPECT().TokenIntrospection("").Return(nil, &globalping.AuthorizeError{Description: "client is not authorized"})
+	gbMock.EXPECT().Limits().Return(&globalping.LimitsResponse{
+		RateLimits: globalping.RateLimits{
+			Measurements: globalping.MeasurementsLimits{
+				Create: globalping.MeasurementsCreateLimits{
+					Type:      "ip",
+					Limit:     500,
+					Remaining: 350,
+					Reset:     600,
+				},
+			},
+		},
+	}, nil)
+
+	w := new(bytes.Buffer)
+	r := new(bytes.Buffer)
+	printer := view.NewPrinter(r, w, w)
+	ctx := createDefaultContext("")
+
+	root := NewRoot(printer, ctx, nil, nil, gbMock, nil, nil)
+
+	os.Args = []string{"globalping", "limits"}
+	err := root.Cmd.ExecuteContext(context.TODO())
+	assert.NoError(t, err)
+
+	assert.Equal(t, `Authentication: IP address
+
+Creating measurements: 
+ - 500 tests per hour
+ - 150 consumed, 350 remaining
+ - resets in 10 minutes
+`, w.String())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,6 +140,7 @@ For more information about the platform, tips, and best practices, visit our Git
 	root.initVersion()
 	root.initHistory()
 	root.initAuth()
+	root.initLimits()
 
 	return root
 }

--- a/globalping/client.go
+++ b/globalping/client.go
@@ -35,9 +35,10 @@ type Client interface {
 	//
 	// onTokenRefresh will be called if the token is successfully removed.
 	Logout() error
-
 	// Revokes the token.
 	RevokeToken(token string) error
+	// Returns the rate limits for the current user or IP address.
+	Limits() (*LimitsResponse, error)
 }
 
 type Config struct {

--- a/globalping/limits.go
+++ b/globalping/limits.go
@@ -1,0 +1,88 @@
+package globalping
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// https://www.jsdelivr.com/docs/api.globalping.io#get-/v1/limits
+type LimitsResponse struct {
+	RateLimits RateLimits   `json:"rateLimit"`
+	Credits    CreditLimits `json:"credits"` // Only for authenticated requests
+}
+
+type RateLimits struct {
+	Measurements MeasurementsLimits `json:"measurements"`
+}
+
+type MeasurementsLimits struct {
+	Create MeasurementsCreateLimits `json:"create"`
+}
+
+type CreateLimitType string
+
+const (
+	CreateLimitTypeIP   CreateLimitType = "ip"
+	CreateLimitTypeUser CreateLimitType = "user"
+)
+
+type MeasurementsCreateLimits struct {
+	Type      CreateLimitType `json:"type"`
+	Limit     int64           `json:"limit"`
+	Remaining int64           `json:"remaining"`
+	Reset     int64           `json:"reset"`
+}
+
+type CreditLimits struct {
+	Remaining int64 `json:"remaining"`
+}
+
+type LimitsError struct {
+	Code    int    `json:"-"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+func (e *LimitsError) Error() string {
+	return e.Message
+}
+
+type LimitsErrorResponse struct {
+	Error *LimitsError `json:"error"`
+}
+
+func (c *client) Limits() (*LimitsResponse, error) {
+	req, err := http.NewRequest("GET", c.apiURL+"/limits", nil)
+	if err != nil {
+		return nil, &LimitsError{Message: "failed to create request - please report this bug"}
+	}
+	token, tokenType, err := c.accessToken()
+	if err != nil {
+		return nil, &LimitsError{Message: "failed to get token: " + err.Error()}
+	}
+	if token != "" {
+		req.Header.Set("Authorization", tokenType+" "+token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, &LimitsError{Message: "request failed - please try again later"}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		errResp := &LimitsErrorResponse{
+			Error: &LimitsError{
+				Code:    resp.StatusCode,
+				Type:    "unexpected_status_code",
+				Message: "unexpected status code: " + resp.Status,
+			},
+		}
+		json.NewDecoder(resp.Body).Decode(errResp)
+		return nil, errResp.Error
+	}
+	limits := &LimitsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(limits)
+	if err != nil {
+		return nil, &LimitsError{Message: "invalid format returned - please report this bug"}
+	}
+	return limits, nil
+}

--- a/globalping/limits_test.go
+++ b/globalping/limits_test.go
@@ -1,0 +1,58 @@
+package globalping
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Limits(t *testing.T) {
+	expectedResponse := &LimitsResponse{
+		RateLimits: RateLimits{
+			Measurements: MeasurementsLimits{
+				Create: MeasurementsCreateLimits{
+					Type:      CreateLimitTypeUser,
+					Limit:     1000,
+					Remaining: 999,
+					Reset:     600,
+				},
+			},
+		},
+		Credits: CreditLimits{
+			Remaining: 1000,
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/limits" && r.Method == http.MethodGet {
+			assert.Equal(t, "Bearer tok3n", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			b, _ := json.Marshal(expectedResponse)
+			_, err := w.Write(b)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		t.Fatalf("unexpected request to %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		AuthClientID:     "<client_id>",
+		AuthClientSecret: "<client_secret>",
+		AuthURL:          server.URL,
+		DashboardURL:     server.URL,
+		APIURL:           server.URL,
+		AuthToken: &Token{
+			AccessToken: "tok3n",
+			Expiry:      time.Now().Add(time.Hour),
+		},
+	})
+	res, err := client.Limits()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedResponse, res)
+}

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -99,6 +99,21 @@ func (mr *MockClientMockRecorder) GetMeasurementRaw(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeasurementRaw", reflect.TypeOf((*MockClient)(nil).GetMeasurementRaw), id)
 }
 
+// Limits mocks base method.
+func (m *MockClient) Limits() (*globalping.LimitsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Limits")
+	ret0, _ := ret[0].(*globalping.LimitsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Limits indicates an expected call of Limits.
+func (mr *MockClientMockRecorder) Limits() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Limits", reflect.TypeOf((*MockClient)(nil).Limits))
+}
+
 // Logout mocks base method.
 func (m *MockClient) Logout() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Adds `limits` command.

Authenticated user:

```
Authentication: token (radulucut)

Creating measurements: 
 - 250 tests per hour
 - 1 consumed, 249 remaining
 - resets in 5 minutes

Credits:
 - 0 credits remaining (may be used to create measurements above the hourly limits)
```

Anonymous user:

```
Authentication: IP address

Creating measurements: 
 - 100000 tests per hour
 - 0 consumed, 100000 remaining
 - resets in 0 seconds
```

#109 