### PR TITLE
fix: OAuth authorize call missing redirect_uri

### DIFF
--- a/globalping/auth.go
+++ b/globalping/auth.go
@@ -97,6 +97,7 @@ func (c *client) Authorize(callback func(error)) (*AuthorizeResponse, error) {
 	q.Set("code_challenge_method", "S256")
 	q.Set("response_type", "code")
 	q.Set("scope", "measurements")
+	q.Set("redirect_uri", callbackURL)
 
 	return &AuthorizeResponse{
 		AuthorizeURL: c.authURL + "/oauth/authorize?" + q.Encode(),

--- a/globalping/auth_test.go
+++ b/globalping/auth_test.go
@@ -76,6 +76,7 @@ func Test_Authorize(t *testing.T) {
 	assert.Equal(t, "S256", u.Query().Get("code_challenge_method"))
 	assert.Equal(t, "code", u.Query().Get("response_type"))
 	assert.Equal(t, "measurements", u.Query().Get("scope"))
+	assert.Equal(t, expectedRedirectURI, u.Query().Get("redirect_uri"))
 
 	_, err = http.Post(res.CallbackURL+"?code=cod3", "application/x-www-form-urlencoded", nil)
 	if err != nil {


### PR DESCRIPTION
Add 'redirect_uri' to the authorize request.

Closes #154 