### PR TITLE
docs: add OPTIONS as a supported HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Usage:
 
 Measurement Commands:
   dns           Resolve DNS records, similar to the dig command
-  http          Perform a HEAD or GET request to a host
+  http          Perform a HEAD, OPTIONS or GET request to a host
   mtr           Run a MTR test, which combines traceroute and ping
   ping          Perform a ping test
   traceroute    Run a traceroute test

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Usage:
 
 Measurement Commands:
   dns           Resolve DNS records, similar to the dig command
-  http          Perform a HEAD, OPTIONS or GET request to a host
+  http          Perform a HEAD, GET, or OPTIONS request to a host
   mtr           Run a MTR test, which combines traceroute and ping
   ping          Perform a ping test
   traceroute    Run a traceroute test

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -19,8 +19,8 @@ func (r *Root) initHTTP(measurementFlags *pflag.FlagSet, localFlags *pflag.FlagS
 		RunE:    r.RunHTTP,
 		Use:     "http [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Perform a HEAD, OPTIONS or GET request to a host",
-		Long: `The http command sends an HTTP request to a host and can perform either HEAD, OPTIONS or GET operations, returning detailed performance statistics for each request. Use it to test and assess the performance and availability of your website, API, or other web services.
+		Short:   "Perform a HEAD, GET, or OPTIONS request to a host",
+		Long: `The http command sends an HTTP request to a host and can perform a HEAD, GET, or OPTIONS operations, returning detailed performance statistics for each request. Use it to test and assess the performance and availability of your website, API, or other web services.
 Note that GET responses are limited to 10KB, with anything beyond this cut by the API.
 
 The CLI tool supports two formats:
@@ -76,7 +76,7 @@ Examples:
 	localFlags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "specify the Host header to add to the request (default host's defined in command target)")
 	localFlags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "specify the URL pathname (default \"/\")")
 	localFlags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "specify a query string to add")
-	localFlags.StringVarP(&r.ctx.Method, "method", "X", r.ctx.Method, "specify the HTTP method to use: HEAD, OPTIONS or GET (default \"HEAD\")")
+	localFlags.StringVarP(&r.ctx.Method, "method", "X", r.ctx.Method, "specify the HTTP method to use: HEAD, GET, or OPTIONS (default \"HEAD\")")
 	localFlags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "add HTTP headers to the request in the format \"Key: Value\"; to add multiple headers, define the flag for each one separately")
 	localFlags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "enable full output when performing an HTTP GET request to display the status, headers, and body")
 	httpCmd.Flags().AddFlagSet(measurementFlags)

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -19,17 +19,17 @@ func (r *Root) initHTTP(measurementFlags *pflag.FlagSet, localFlags *pflag.FlagS
 		RunE:    r.RunHTTP,
 		Use:     "http [target] from [location | measurement ID | @1 | first | @-1 | last | previous]",
 		GroupID: "Measurements",
-		Short:   "Perform a HEAD or GET request to a host",
-		Long: `The http command sends an HTTP request to a host and can perform either HEAD or GET operations, returning detailed performance statistics for each request. Use it to test and assess the performance and availability of your website, API, or other web services. 
-Note that GET responses are limited to 10KB, with anything beyond this cut by the API. 
+		Short:   "Perform a HEAD, OPTIONS or GET request to a host",
+		Long: `The http command sends an HTTP request to a host and can perform either HEAD, OPTIONS or GET operations, returning detailed performance statistics for each request. Use it to test and assess the performance and availability of your website, API, or other web services.
+Note that GET responses are limited to 10KB, with anything beyond this cut by the API.
 
-The CLI tool supports two formats: 
+The CLI tool supports two formats:
 1. Full URL: The tool automatically parses the scheme, host, port, domain, path, and query. For example:
 	http https://www.jsdelivr.com:443/package/npm/test?nav=stats
 2. Separate flags: Specify the scheme, host, port, domain, path, and query as separate command line flags, useful for scripting. For example:
 	http jsdelivr.com --host www.jsdelivr.com --protocol https --port 443 --path "/package/npm/test" --query "nav=stats"
 
-Note that a probe's local settings or DHCP determine the default nameserver the command uses. To specify a DNS resolver, use the --resolver argument or @resolver format:  
+Note that a probe's local settings or DHCP determine the default nameserver the command uses. To specify a DNS resolver, use the --resolver argument or @resolver format:
 - http jsdelivr.com from Berlin --resolver 1.1.1.1
 - http jsdelivr.com @1.1.1.1 from Berlin
 
@@ -76,7 +76,7 @@ Examples:
 	localFlags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "specify the Host header to add to the request (default host's defined in command target)")
 	localFlags.StringVar(&r.ctx.Path, "path", r.ctx.Path, "specify the URL pathname (default \"/\")")
 	localFlags.StringVar(&r.ctx.Query, "query", r.ctx.Query, "specify a query string to add")
-	localFlags.StringVarP(&r.ctx.Method, "method", "X", r.ctx.Method, "specify the HTTP method to use: HEAD or GET (default \"HEAD\")")
+	localFlags.StringVarP(&r.ctx.Method, "method", "X", r.ctx.Method, "specify the HTTP method to use: HEAD, OPTIONS or GET (default \"HEAD\")")
 	localFlags.StringArrayVarP(&r.ctx.Headers, "header", "H", r.ctx.Headers, "add HTTP headers to the request in the format \"Key: Value\"; to add multiple headers, define the flag for each one separately")
 	localFlags.BoolVar(&r.ctx.Full, "full", r.ctx.Full, "enable full output when performing an HTTP GET request to display the status, headers, and body")
 	httpCmd.Flags().AddFlagSet(measurementFlags)


### PR DESCRIPTION
Closes #157 