### PR TITLE
fix: change the default HTTP protocol to HTTPS

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -70,7 +70,7 @@ Examples:
 
 	// http specific flags
 	localFlags.BoolP("help", "h", false, "help for http")
-	localFlags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "specify the protocol to use: HTTP, HTTPS, or HTTP2  (default \"HTTP\")")
+	localFlags.StringVar(&r.ctx.Protocol, "protocol", r.ctx.Protocol, "specify the protocol to use: HTTP, HTTPS, or HTTP2  (default \"HTTPS\")")
 	localFlags.IntVar(&r.ctx.Port, "port", r.ctx.Port, "specify the port to use (default 80 for HTTP, 443 for HTTPS and HTTP2)")
 	localFlags.StringVar(&r.ctx.Resolver, "resolver", r.ctx.Resolver, "specify the hostname or IP address of the name server to use for the DNS lookup (default defined by the probe)")
 	localFlags.StringVar(&r.ctx.Host, "host", r.ctx.Host, "specify the Host header to add to the request (default host's defined in command target)")
@@ -204,7 +204,7 @@ func parseUrlData(input string) (*UrlData, error) {
 
 	// add url scheme if missing
 	if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {
-		input = "http://" + input
+		input = "https://" + input
 	}
 
 	// Parse input

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -95,7 +95,7 @@ func Test_Execute_HTTP_IPv4(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedOpts := createDefaultMeasurementCreate("http")
-	expectedOpts.Options.Protocol = "http"
+	expectedOpts.Options.Protocol = "https"
 	expectedOpts.Options.IPVersion = globalping.IPVersion4
 	expectedOpts.Options.Request = &globalping.RequestOptions{
 		Headers: map[string]string{},
@@ -137,7 +137,7 @@ func Test_Execute_HTTP_IPv6(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedOpts := createDefaultMeasurementCreate("http")
-	expectedOpts.Options.Protocol = "http"
+	expectedOpts.Options.Protocol = "https"
 	expectedOpts.Options.IPVersion = globalping.IPVersion6
 	expectedOpts.Options.Request = &globalping.RequestOptions{
 		Headers: map[string]string{},
@@ -189,7 +189,7 @@ func Test_ParseUrlData_NoScheme(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "cdn.jsdelivr.net", urlData.Host)
 	assert.Equal(t, "/npm/react/", urlData.Path)
-	assert.Equal(t, "http", urlData.Protocol)
+	assert.Equal(t, "https", urlData.Protocol)
 	assert.Equal(t, 0, urlData.Port)
 	assert.Equal(t, "query=3", urlData.Query)
 }
@@ -199,7 +199,7 @@ func Test_ParseUrlData_HostOnly(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "cdn.jsdelivr.net", urlData.Host)
 	assert.Equal(t, "", urlData.Path)
-	assert.Equal(t, "http", urlData.Protocol)
+	assert.Equal(t, "https", urlData.Protocol)
 	assert.Equal(t, 0, urlData.Port)
 	assert.Equal(t, "", urlData.Query)
 }


### PR DESCRIPTION
Our API and web default to HTTPS if not specified, and so should the CLI.