### PR TITLE
feat: add AwaitMeasurement, set default urls

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,10 +61,7 @@ func Execute() {
 		}
 	}
 	globalpingClient := globalping.NewClientWithCacheCleanup(globalping.Config{
-		APIURL:       config.GlobalpingAPIURL,
-		AuthURL:      config.GlobalpingAuthURL,
-		DashboardURL: config.GlobalpingDashboardURL,
-		AuthToken:    token,
+		AuthToken: token,
 		OnTokenRefresh: func(token *globalping.Token) {
 			profile.Token = token
 			err := localStorage.SaveConfig()

--- a/mocks/mock_client.go
+++ b/mocks/mock_client.go
@@ -54,6 +54,21 @@ func (mr *MockClientMockRecorder) Authorize(callback any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authorize", reflect.TypeOf((*MockClient)(nil).Authorize), callback)
 }
 
+// AwaitMeasurement mocks base method.
+func (m *MockClient) AwaitMeasurement(id string) (*globalping.Measurement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AwaitMeasurement", id)
+	ret0, _ := ret[0].(*globalping.Measurement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AwaitMeasurement indicates an expected call of AwaitMeasurement.
+func (mr *MockClientMockRecorder) AwaitMeasurement(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitMeasurement", reflect.TypeOf((*MockClient)(nil).AwaitMeasurement), id)
+}
+
 // CreateMeasurement mocks base method.
 func (m *MockClient) CreateMeasurement(measurement *globalping.MeasurementCreate) (*globalping.MeasurementCreateResponse, error) {
 	m.ctrl.T.Helper()

--- a/utils/config.go
+++ b/utils/config.go
@@ -7,9 +7,6 @@ import (
 
 type Config struct {
 	GlobalpingToken            string
-	GlobalpingAPIURL           string
-	GlobalpingAuthURL          string
-	GlobalpingDashboardURL     string
 	GlobalpingAuthClientID     string
 	GlobalpingAuthClientSecret string
 	GlobalpingAPIInterval      _time.Duration
@@ -17,9 +14,6 @@ type Config struct {
 
 func NewConfig() *Config {
 	return &Config{
-		GlobalpingAPIURL:           "https://api.globalping.io/v1",
-		GlobalpingAuthURL:          "https://auth.globalping.io",
-		GlobalpingDashboardURL:     "https://dash.globalping.io",
 		GlobalpingAuthClientID:     "be231712-03f4-45bf-9f15-023506ce0b72",
 		GlobalpingAuthClientSecret: "public",
 		GlobalpingAPIInterval:      500 * _time.Millisecond,

--- a/view/output.go
+++ b/view/output.go
@@ -12,6 +12,7 @@ import (
 
 var ShareURL = "https://globalping.io?measurement="
 
+// TODO: Use globalping.AwaitMeasurement instead of GetMeasurement
 func (v *viewer) Output(id string, m *globalping.MeasurementCreate) error {
 	// Wait for first result to arrive from a probe before starting display (can be in-progress)
 	data, err := v.globalping.GetMeasurement(id)


### PR DESCRIPTION
- adds AwaitMeasurement that waits for the measurement to complete.
- set the default urls for the API.
