### PR TITLE
fix: bind auth callback listener only to localhost

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -48,8 +48,10 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 		Handler: mux,
 	}
 	var callbackOnce sync.Once
+	authorizeDone := make(chan struct{})
 	finish := func(err error, token *storage.Token) {
 		callbackOnce.Do(func() {
+			close(authorizeDone)
 			go func() {
 				server.Shutdown(context.Background())
 				if err == nil {
@@ -116,6 +118,13 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 		}
 		if serveErr != nil {
 			finish(&AuthorizeError{ErrorType: "failed to start server", Description: serveErr.Error()}, nil)
+		}
+	}()
+	go func() {
+		select {
+		case <-ctx.Done():
+			finish(ctx.Err(), nil)
+		case <-authorizeDone:
 		}
 	}()
 	callbackURL = "http://localhost:" + port + "/callback"

--- a/api/auth.go
+++ b/api/auth.go
@@ -69,25 +69,36 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 		}()
 	})
 	var err error
-	var ln net.Listener
+	var listeners []net.Listener
 	ports := []int{60000, 60010, 60020, 60030, 60040, 60100, 60110, 60120, 60130, 60140}
 	port := ""
 	for i := range ports {
 		port = strconv.Itoa(ports[i])
-		ln, err = net.Listen("tcp", "127.0.0.1:"+port)
-		if err == nil {
-			break
+		ln4, listenErr := net.Listen("tcp4", net.JoinHostPort("127.0.0.1", port))
+		if listenErr != nil {
+			err = listenErr
+			continue
 		}
+		ln6, listenErr := net.Listen("tcp6", net.JoinHostPort("::1", port))
+		if listenErr != nil {
+			ln4.Close()
+			err = listenErr
+			continue
+		}
+		listeners = []net.Listener{ln4, ln6}
+		break
 	}
-	if err != nil {
+	if len(listeners) == 0 {
 		return nil, err
 	}
-	go func() {
-		err := server.Serve(ln)
-		if err != nil && err != http.ErrServerClosed {
-			callback(&AuthorizeError{ErrorType: "failed to start server", Description: err.Error()})
-		}
-	}()
+	for _, ln := range listeners {
+		go func(ln net.Listener) {
+			err := server.Serve(ln)
+			if err != nil && err != http.ErrServerClosed {
+				callback(&AuthorizeError{ErrorType: "failed to start server", Description: err.Error()})
+			}
+		}(ln)
+	}
 	callbackURL = "http://localhost:" + port + "/callback"
 	q := url.Values{}
 	q.Set("client_id", c.authClientId)

--- a/api/auth.go
+++ b/api/auth.go
@@ -6,12 +6,14 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/jsdelivr/globalping-cli/storage"
@@ -79,23 +81,38 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 	})
 	var err error
 	var listeners []net.Listener
+	const wsaAddrInUse = syscall.Errno(10048)
+	isAddrInUse := func(err error) bool {
+		return errors.Is(err, syscall.EADDRINUSE) || errors.Is(err, wsaAddrInUse)
+	}
 	ports := []int{60000, 60010, 60020, 60030, 60040, 60100, 60110, 60120, 60130, 60140}
 	port := ""
 	for i := range ports {
 		port = strconv.Itoa(ports[i])
+		portListeners := []net.Listener{}
 		ln4, listenErr := net.Listen("tcp4", net.JoinHostPort("127.0.0.1", port))
 		if listenErr == nil {
-			listeners = append(listeners, ln4)
+			portListeners = append(portListeners, ln4)
 		} else {
 			err = listenErr
+			if isAddrInUse(listenErr) {
+				continue
+			}
 		}
 		ln6, listenErr := net.Listen("tcp6", net.JoinHostPort("::1", port))
 		if listenErr == nil {
-			listeners = append(listeners, ln6)
+			portListeners = append(portListeners, ln6)
 		} else {
 			err = listenErr
+			if isAddrInUse(listenErr) {
+				for _, ln := range portListeners {
+					ln.Close()
+				}
+				continue
+			}
 		}
-		if len(listeners) != 0 {
+		if len(portListeners) != 0 {
+			listeners = portListeners
 			break
 		}
 	}

--- a/api/auth.go
+++ b/api/auth.go
@@ -100,14 +100,24 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 	if len(listeners) == 0 {
 		return nil, err
 	}
+	serveErrors := make(chan error, len(listeners))
 	for _, ln := range listeners {
 		go func(ln net.Listener) {
-			err := server.Serve(ln)
-			if err != nil && err != http.ErrServerClosed {
-				finish(&AuthorizeError{ErrorType: "failed to start server", Description: err.Error()}, nil)
-			}
+			serveErrors <- server.Serve(ln)
 		}(ln)
 	}
+	go func() {
+		var serveErr error
+		for range listeners {
+			err := <-serveErrors
+			if err != nil && err != http.ErrServerClosed {
+				serveErr = err
+			}
+		}
+		if serveErr != nil {
+			finish(&AuthorizeError{ErrorType: "failed to start server", Description: serveErr.Error()}, nil)
+		}
+	}()
 	callbackURL = "http://localhost:" + port + "/callback"
 	q := url.Values{}
 	q.Set("client_id", c.authClientId)

--- a/api/auth.go
+++ b/api/auth.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jsdelivr/globalping-cli/storage"
@@ -46,12 +47,24 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 	server := &http.Server{
 		Handler: mux,
 	}
+	var callbackOnce sync.Once
+	finish := func(err error, token *storage.Token) {
+		callbackOnce.Do(func() {
+			go func() {
+				server.Shutdown(context.Background())
+				if err == nil {
+					c.updateToken(token)
+				}
+				callback(err)
+			}()
+		})
+	}
 	callbackURL := ""
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, req *http.Request) {
 		err := req.ParseForm()
 		if err != nil {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
-			callback(&AuthorizeError{ErrorType: "failed to parse form", Description: err.Error()})
+			finish(&AuthorizeError{ErrorType: "failed to parse form", Description: err.Error()}, nil)
 			return
 		}
 		token, err := c.exchange(ctx, req.Form, verifier, callbackURL)
@@ -60,13 +73,7 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 		} else {
 			http.Redirect(w, req, c.dashboardURL+"/authorize/success", http.StatusFound)
 		}
-		go func() {
-			server.Shutdown(context.Background())
-			if err == nil {
-				c.updateToken(token)
-			}
-			callback(err)
-		}()
+		finish(err, token)
 	})
 	var err error
 	var listeners []net.Listener
@@ -75,18 +82,20 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 	for i := range ports {
 		port = strconv.Itoa(ports[i])
 		ln4, listenErr := net.Listen("tcp4", net.JoinHostPort("127.0.0.1", port))
-		if listenErr != nil {
+		if listenErr == nil {
+			listeners = append(listeners, ln4)
+		} else {
 			err = listenErr
-			continue
 		}
 		ln6, listenErr := net.Listen("tcp6", net.JoinHostPort("::1", port))
-		if listenErr != nil {
-			ln4.Close()
+		if listenErr == nil {
+			listeners = append(listeners, ln6)
+		} else {
 			err = listenErr
-			continue
 		}
-		listeners = []net.Listener{ln4, ln6}
-		break
+		if len(listeners) != 0 {
+			break
+		}
 	}
 	if len(listeners) == 0 {
 		return nil, err
@@ -95,7 +104,7 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 		go func(ln net.Listener) {
 			err := server.Serve(ln)
 			if err != nil && err != http.ErrServerClosed {
-				callback(&AuthorizeError{ErrorType: "failed to start server", Description: err.Error()})
+				finish(&AuthorizeError{ErrorType: "failed to start server", Description: err.Error()}, nil)
 			}
 		}(ln)
 	}

--- a/api/auth.go
+++ b/api/auth.go
@@ -74,7 +74,7 @@ func (c *client) Authorize(ctx context.Context, callback func(error)) (*Authoriz
 	port := ""
 	for i := range ports {
 		port = strconv.Itoa(ports[i])
-		ln, err = net.Listen("tcp", ":"+port)
+		ln, err = net.Listen("tcp", "127.0.0.1:"+port)
 		if err == nil {
 			break
 		}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -22,6 +22,7 @@ func Test_Authorize(t *testing.T) {
 	utilsMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
 
 	succesCalled := false
+	authorizeDone := make(chan error, 1)
 	expectedRedirectURI := ""
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/authorize/error" {
@@ -67,7 +68,7 @@ func Test_Authorize(t *testing.T) {
 		DashboardURL:     server.URL,
 	})
 	res, err := client.Authorize(t.Context(), func(err error) {
-		assert.Nil(t, err)
+		authorizeDone <- err
 	})
 	assert.Nil(t, err)
 	expectedRedirectURI = res.CallbackURL
@@ -86,6 +87,12 @@ func Test_Authorize(t *testing.T) {
 	_, err = http.Post(res.CallbackURL+"?code=cod3", "application/x-www-form-urlencoded", nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	select {
+	case err := <-authorizeDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("authorization callback timed out")
 	}
 
 	assert.True(t, succesCalled, "/authorize/success not called")

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,8 @@ import (
 )
 
 func Test_Authorize(t *testing.T) {
+	const authorizationTimeout = 5 * time.Second
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -67,7 +70,9 @@ func Test_Authorize(t *testing.T) {
 		AuthURL:          server.URL,
 		DashboardURL:     server.URL,
 	})
-	res, err := client.Authorize(t.Context(), func(err error) {
+	authorizeCtx, cancelAuthorize := context.WithCancel(t.Context())
+	defer cancelAuthorize()
+	res, err := client.Authorize(authorizeCtx, func(err error) {
 		authorizeDone <- err
 	})
 	assert.Nil(t, err)
@@ -91,8 +96,14 @@ func Test_Authorize(t *testing.T) {
 	select {
 	case err := <-authorizeDone:
 		assert.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("authorization callback timed out")
+	case <-time.After(authorizationTimeout):
+		cancelAuthorize()
+		select {
+		case <-authorizeDone:
+			t.Fatal("authorization callback timed out")
+		case <-time.After(authorizationTimeout):
+			t.Fatal("authorization listener cleanup timed out")
+		}
 	}
 
 	assert.True(t, succesCalled, "/authorize/success not called")


### PR DESCRIPTION
Removes a network access popup, e.g., when running `globalping auth login`.