### PR TITLE
chore: upgrade globalping-go to v0.2.0

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -114,6 +114,10 @@ func (r *Root) updateContext(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if r.ctx.Limit < 1 {
+		return errors.New("limit must be at least 1")
+	}
+
 	// Check env for CI
 	if os.Getenv("CI") != "" {
 		r.ctx.CIMode = true

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -58,7 +58,7 @@ func (r *Root) handleMeasurement(ctx context.Context, id string, opts *globalpin
 
 	w, h := r.printer.GetSize()
 	// Poll API until the measurement is complete
-	for res.Status == globalping.StatusInProgress {
+	for res.Status == globalping.MeasurementStatusInProgress {
 		time.Sleep(r.ctx.APIMinInterval)
 		res, err = r.client.GetMeasurement(ctx, id)
 		if err != nil {
@@ -142,7 +142,7 @@ func (r *Root) updateContext(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (r *Root) getLocations() ([]globalping.Locations, error) {
+func (r *Root) getLocations() (globalping.LocationSelection, error) {
 	fromArr := strings.Split(r.ctx.From, ",")
 	if len(fromArr) == 1 {
 		mId, err := r.mapFromSession(fromArr[0])
@@ -150,14 +150,13 @@ func (r *Root) getLocations() ([]globalping.Locations, error) {
 			return nil, err
 		}
 		if mId == "" {
-			mId = strings.TrimSpace(fromArr[0])
-		} else {
-			r.ctx.IsLocationFromSession = true
-			r.ctx.RecordToSession = false
+			return globalping.LocationOptions{{Magic: strings.TrimSpace(fromArr[0])}}, nil
 		}
-		return []globalping.Locations{{Magic: mId}}, nil
+		r.ctx.IsLocationFromSession = true
+		r.ctx.RecordToSession = false
+		return globalping.PreviousMeasurementID(mId), nil
 	}
-	locations := make([]globalping.Locations, len(fromArr))
+	locations := make(globalping.LocationOptions, len(fromArr))
 	for i, v := range fromArr {
 		locations[i] = globalping.Locations{
 			Magic: strings.TrimSpace(v),

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -16,6 +16,7 @@ func Test_UpdateContext(t *testing.T) {
 		"country":               test_updateContext_Country,
 		"country_whitespace":    test_updateContext_CountryWhitespace,
 		"no_target":             test_updateContext_NoTarget,
+		"limit_below_minimum":   test_updateContext_LimitBelowMinimum,
 		"ci_env":                test_updateContext_CIEnv,
 		"target_not_hostname":   test_updateContext_TargetIsNotAHostname,
 		"resolver_not_hostname": test_updateContext_ResolverIsNotAHostname,
@@ -82,6 +83,19 @@ func test_updateContext_NoTarget(t *testing.T) {
 
 	err := root.updateContext(cmd, []string{})
 	assert.Error(t, err)
+}
+
+func test_updateContext_LimitBelowMinimum(t *testing.T) {
+	ctx := createDefaultContext("ping")
+	ctx.Limit = 0
+	printer := view.NewPrinter(nil, nil, nil)
+	root := NewRoot(printer, ctx, nil, nil, nil, nil, nil)
+
+	cmd := &cobra.Command{Use: "ping"}
+	cmd.Execute()
+
+	err := root.updateContext(cmd, []string{"1.1.1.1"})
+	assert.EqualError(t, err, "limit must be at least 1")
 }
 
 func test_updateContext_CIEnv(t *testing.T) {

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -121,7 +121,7 @@ func (r *Root) RunDNS(cmd *cobra.Command, args []string) error {
 	r.ctx.MeasurementsCreated++
 	hm := &view.HistoryItem{
 		Id:        res.ID,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: r.utils.Now(),
 	}
 	r.ctx.History.Push(hm)

--- a/cmd/history_test.go
+++ b/cmd/history_test.go
@@ -28,7 +28,7 @@ func Test_Execute_History_Default(t *testing.T) {
 
 	ctx.History.Push(&view.HistoryItem{
 		Id:        measurementID1,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: defaultCurrentTime,
 	})
 	root.UpdateHistory()
@@ -37,7 +37,7 @@ func Test_Execute_History_Default(t *testing.T) {
 	ctx.IsLocationFromSession = true
 	ctx.History.Push(&view.HistoryItem{
 		Id:        measurementID2,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: defaultCurrentTime,
 	})
 	root.UpdateHistory()
@@ -49,7 +49,7 @@ func Test_Execute_History_Default(t *testing.T) {
 	root.UpdateHistory()
 	ctx.History.Push(&view.HistoryItem{
 		Id:        measurementID3,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: defaultCurrentTime,
 	})
 	root.UpdateHistory()

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -131,7 +131,7 @@ func (r *Root) RunHTTP(cmd *cobra.Command, args []string) error {
 	r.ctx.MeasurementsCreated++
 	hm := &view.HistoryItem{
 		Id:        res.ID,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: r.utils.Now(),
 	}
 	r.ctx.History.Push(hm)

--- a/cmd/mtr.go
+++ b/cmd/mtr.go
@@ -110,7 +110,7 @@ func (r *Root) RunMTR(cmd *cobra.Command, args []string) error {
 	r.ctx.MeasurementsCreated++
 	hm := &view.HistoryItem{
 		Id:        res.ID,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: r.utils.Now(),
 	}
 	r.ctx.History.Push(hm)

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -169,16 +169,16 @@ func (r *Root) ping(ctx context.Context, opts *globalping.MeasurementCreate) err
 				r.Cmd.SilenceUsage = true
 				return err
 			}
-			if measurement.Status != globalping.StatusInProgress {
+			if measurement.Status != globalping.MeasurementStatusInProgress {
 				mbuf.Remove(el)
 			} else {
-				el.ProbeStatus = make([]globalping.MeasurementStatus, len(measurement.Results))
+				el.ProbeStatus = make([]globalping.TestStatus, len(measurement.Results))
 				for i := range measurement.Results {
 					el.ProbeStatus[i] = measurement.Results[i].Result.Status
 				}
 			}
 			if runErr == nil && mbuf.CanAppend() {
-				opts.Locations = []globalping.Locations{{Magic: r.ctx.History.Last().Id}}
+				opts.Locations = globalping.PreviousMeasurementID(r.ctx.History.Last().Id)
 				start := r.utils.Now()
 				hm, err := r.createMeasurement(ctx, opts)
 				if err != nil {
@@ -199,7 +199,7 @@ func (r *Root) ping(ctx context.Context, opts *globalping.MeasurementCreate) err
 		}
 		last := r.ctx.History.Last()
 		if last != nil {
-			opts.Locations = []globalping.Locations{{Magic: last.Id}}
+			opts.Locations = globalping.PreviousMeasurementID(last.Id)
 		}
 		hm, err := r.createMeasurement(ctx, opts)
 		if err != nil {
@@ -218,7 +218,7 @@ func (r *Root) createMeasurement(ctx context.Context, opts *globalping.Measureme
 	r.ctx.MeasurementsCreated++
 	hm := &view.HistoryItem{
 		Id:        res.ID,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: r.utils.Now(),
 	}
 	r.ctx.History.Push(hm)
@@ -294,7 +294,7 @@ func (b *MeasurementsBuffer) CanAppend() bool {
 			return false
 		}
 		for j := range b.items[i].ProbeStatus {
-			inProgressMat[j] = inProgressMat[j] || b.items[i].ProbeStatus[j] != globalping.StatusFinished
+			inProgressMat[j] = inProgressMat[j] || b.items[i].ProbeStatus[j] != globalping.TestStatusFinished
 		}
 	}
 	for _, inProgress := range inProgressMat {

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -23,7 +23,7 @@ func Test_Execute_Ping_Default(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedOpts := createDefaultMeasurementCreate("ping")
-	expectedOpts.Locations[0].Magic = "world"
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "world"}}
 	expectedResponse := createDefaultMeasurementCreateResponse()
 
 	gbMock := apiMocks.NewMockClient(ctrl)
@@ -74,7 +74,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedOpts := createDefaultMeasurementCreate("ping")
-	expectedOpts.Locations = append(expectedOpts.Locations, globalping.Locations{Magic: "New York"})
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "Berlin"}, {Magic: "New York"}}
 	expectedResponse := createDefaultMeasurementCreateResponse()
 
 	totalCalls := 10
@@ -108,7 +108,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID1)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@-1"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -119,7 +119,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID1)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "last"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -129,7 +129,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID1)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "previous"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -139,7 +139,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: "world"}}
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "world"}}
 	expectedResponse.ID = measurementID2
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com"}
@@ -152,7 +152,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID1)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@1"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -163,7 +163,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID1)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "first"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -173,7 +173,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: "world"}}
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "world"}}
 	expectedResponse.ID = measurementID3
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com"}
@@ -186,7 +186,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID2}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID2)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@2"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -198,7 +198,7 @@ func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 
 	ctx = createDefaultContext("ping")
-	expectedOpts.Locations = []globalping.Locations{{Magic: measurementID1}}
+	expectedOpts.Locations = globalping.PreviousMeasurementID(measurementID1)
 	root = NewRoot(printer, ctx, viewerMock, utilsMock, gbMock, nil, _storage)
 	os.Args = []string{"globalping", "ping", "jsdelivr.com", "from", "@-3"}
 	err = root.Cmd.ExecuteContext(t.Context())
@@ -283,13 +283,13 @@ func Test_Execute_Ping_Infinite(t *testing.T) {
 	expectedOpts1.Options.Packets = 16
 	expectedOpts2 := createDefaultMeasurementCreate("ping")
 	expectedOpts2.Options.Packets = 16
-	expectedOpts2.Locations[0].Magic = measurementID1
+	expectedOpts2.Locations = globalping.PreviousMeasurementID(measurementID1)
 	expectedOpts3 := createDefaultMeasurementCreate("ping")
 	expectedOpts3.Options.Packets = 16
-	expectedOpts3.Locations[0].Magic = measurementID2
+	expectedOpts3.Locations = globalping.PreviousMeasurementID(measurementID2)
 	expectedOpts4 := createDefaultMeasurementCreate("ping")
 	expectedOpts4.Options.Packets = 16
-	expectedOpts4.Locations[0].Magic = measurementID3
+	expectedOpts4.Locations = globalping.PreviousMeasurementID(measurementID3)
 
 	expectedResponse1 := createDefaultMeasurementCreateResponse()
 	expectedResponse2 := createDefaultMeasurementCreateResponse()
@@ -305,16 +305,16 @@ func Test_Execute_Ping_Infinite(t *testing.T) {
 	gbMock.EXPECT().CreateMeasurement(t.Context(), expectedOpts3).Return(expectedResponse3, nil)
 	gbMock.EXPECT().CreateMeasurement(t.Context(), expectedOpts4).Return(expectedResponse4, nil)
 
-	expectedMeasurement1 := createDefaultMeasurement_MultipleProbes("ping", globalping.StatusFinished)
-	expectedMeasurement2 := createDefaultMeasurement_MultipleProbes("ping", globalping.StatusInProgress)
+	expectedMeasurement1 := createDefaultMeasurement_MultipleProbes("ping", globalping.MeasurementStatusFinished, globalping.TestStatusFinished)
+	expectedMeasurement2 := createDefaultMeasurement_MultipleProbes("ping", globalping.MeasurementStatusInProgress, globalping.TestStatusInProgress)
 	expectedMeasurement2.ID = measurementID2
-	expectedMeasurement2.Results[0].Result.Status = globalping.StatusFinished
-	expectedMeasurement3 := createDefaultMeasurement_MultipleProbes("ping", globalping.StatusInProgress)
+	expectedMeasurement2.Results[0].Result.Status = globalping.TestStatusFinished
+	expectedMeasurement3 := createDefaultMeasurement_MultipleProbes("ping", globalping.MeasurementStatusInProgress, globalping.TestStatusInProgress)
 	expectedMeasurement3.ID = measurementID3
-	expectedMeasurement3.Results[0].Result.Status = globalping.StatusFinished
-	expectedMeasurement4 := createDefaultMeasurement_MultipleProbes("ping", globalping.StatusInProgress)
+	expectedMeasurement3.Results[0].Result.Status = globalping.TestStatusFinished
+	expectedMeasurement4 := createDefaultMeasurement_MultipleProbes("ping", globalping.MeasurementStatusInProgress, globalping.TestStatusInProgress)
 	expectedMeasurement4.ID = measurementID4
-	expectedMeasurement4.Results[1].Result.Status = globalping.StatusFinished
+	expectedMeasurement4.Results[1].Result.Status = globalping.TestStatusFinished
 
 	gbMock.EXPECT().GetMeasurement(t.Context(), measurementID1).Return(expectedMeasurement1, nil)
 	gbMock.EXPECT().GetMeasurement(t.Context(), measurementID2).Return(expectedMeasurement2, nil)
@@ -381,36 +381,36 @@ func Test_Execute_Ping_Infinite(t *testing.T) {
 		Slice: []*view.HistoryItem{
 			{
 				Id:        measurementID1,
-				Status:    globalping.StatusFinished,
+				Status:    globalping.MeasurementStatusFinished,
 				StartedAt: defaultCurrentTime,
 			},
 			{
 				Id:     measurementID2,
-				Status: globalping.StatusInProgress,
-				ProbeStatus: []globalping.MeasurementStatus{
-					globalping.StatusFinished,
-					globalping.StatusInProgress,
-					globalping.StatusInProgress,
+				Status: globalping.MeasurementStatusInProgress,
+				ProbeStatus: []globalping.TestStatus{
+					globalping.TestStatusFinished,
+					globalping.TestStatusInProgress,
+					globalping.TestStatusInProgress,
 				},
 				StartedAt: defaultCurrentTime,
 			},
 			{
 				Id:     measurementID3,
-				Status: globalping.StatusInProgress,
-				ProbeStatus: []globalping.MeasurementStatus{
-					globalping.StatusFinished,
-					globalping.StatusInProgress,
-					globalping.StatusInProgress,
+				Status: globalping.MeasurementStatusInProgress,
+				ProbeStatus: []globalping.TestStatus{
+					globalping.TestStatusFinished,
+					globalping.TestStatusInProgress,
+					globalping.TestStatusInProgress,
 				},
 				StartedAt: defaultCurrentTime,
 			},
 			{
 				Id:     measurementID4,
-				Status: globalping.StatusInProgress,
-				ProbeStatus: []globalping.MeasurementStatus{
-					globalping.StatusInProgress,
-					globalping.StatusFinished,
-					globalping.StatusInProgress,
+				Status: globalping.MeasurementStatusInProgress,
+				ProbeStatus: []globalping.TestStatus{
+					globalping.TestStatusInProgress,
+					globalping.TestStatusFinished,
+					globalping.TestStatusInProgress,
 				},
 				StartedAt: defaultCurrentTime,
 			},
@@ -469,7 +469,7 @@ func Test_Execute_Ping_Infinite_Output_Error(t *testing.T) {
 	assert.Equal(t, "Error: error message\n", w.String())
 
 	expectedCtx := createDefaultExpectedContext("ping")
-	expectedCtx.History.Find(measurementID1).Status = globalping.StatusFinished
+	expectedCtx.History.Find(measurementID1).Status = globalping.MeasurementStatusFinished
 	expectedCtx.Packets = 16
 	expectedCtx.Infinite = true
 	assert.Equal(t, expectedCtx, ctx)
@@ -497,7 +497,7 @@ func Test_Execute_Ping_Infinite_Output_TooManyRequests_Error(t *testing.T) {
 	expectedOpts1.Options.Packets = 16
 	expectedOpts2 := createDefaultMeasurementCreate("ping")
 	expectedOpts2.Options.Packets = 16
-	expectedOpts2.Locations[0].Magic = measurementID1
+	expectedOpts2.Locations = globalping.PreviousMeasurementID(measurementID1)
 
 	expectedResponse1 := createDefaultMeasurementCreateResponse()
 
@@ -536,7 +536,7 @@ func Test_Execute_Ping_Infinite_Output_TooManyRequests_Error(t *testing.T) {
 	assert.Equal(t, "", w.String())
 
 	expectedCtx := createDefaultExpectedContext("ping")
-	expectedCtx.History.Find(measurementID1).Status = globalping.StatusFinished
+	expectedCtx.History.Find(measurementID1).Status = globalping.MeasurementStatusFinished
 	expectedCtx.Packets = 16
 	expectedCtx.Infinite = true
 	expectedCtx.Share = true
@@ -562,7 +562,7 @@ func Test_Execute_Ping_IPv4(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedOpts := createDefaultMeasurementCreate("ping")
-	expectedOpts.Locations[0].Magic = "world"
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "world"}}
 	expectedOpts.Options.IPVersion = globalping.IPVersion4
 	expectedResponse := createDefaultMeasurementCreateResponse()
 
@@ -601,7 +601,7 @@ func Test_Execute_Ping_IPv6(t *testing.T) {
 	defer ctrl.Finish()
 
 	expectedOpts := createDefaultMeasurementCreate("ping")
-	expectedOpts.Locations[0].Magic = "world"
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "world"}}
 	expectedOpts.Options.IPVersion = globalping.IPVersion6
 	expectedResponse := createDefaultMeasurementCreateResponse()
 

--- a/cmd/traceroute.go
+++ b/cmd/traceroute.go
@@ -111,7 +111,7 @@ func (r *Root) RunTraceroute(cmd *cobra.Command, args []string) error {
 	r.ctx.MeasurementsCreated++
 	hm := &view.HistoryItem{
 		Id:        res.ID,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: r.utils.Now(),
 	}
 	r.ctx.History.Push(hm)

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -33,7 +33,7 @@ func createDefaultMeasurementCreate(cmd globalping.MeasurementType) *globalping.
 		Target:  "jsdelivr.com",
 		Limit:   1,
 		Options: &globalping.MeasurementOptions{},
-		Locations: []globalping.Locations{
+		Locations: globalping.LocationOptions{
 			{Magic: "Berlin"},
 		},
 	}
@@ -60,39 +60,39 @@ func createDefaultMeasurementCreate(cmd globalping.MeasurementType) *globalping.
 func createDefaultMeasurement(cmd globalping.MeasurementType) *globalping.Measurement {
 	return &globalping.Measurement{
 		ID:          measurementID1,
-		Status:      globalping.StatusFinished,
+		Status:      globalping.MeasurementStatusFinished,
 		Type:        cmd,
 		ProbesCount: 1,
 		Results: []globalping.ProbeMeasurement{
 			{
 				Result: globalping.ProbeResult{
-					Status: globalping.StatusFinished,
+					Status: globalping.TestStatusFinished,
 				},
 			},
 		},
 	}
 }
 
-func createDefaultMeasurement_MultipleProbes(cmd globalping.MeasurementType, status globalping.MeasurementStatus) *globalping.Measurement {
+func createDefaultMeasurement_MultipleProbes(cmd globalping.MeasurementType, measurementStatus globalping.MeasurementStatus, testStatus globalping.TestStatus) *globalping.Measurement {
 	return &globalping.Measurement{
 		ID:          measurementID1,
-		Status:      status,
+		Status:      measurementStatus,
 		Type:        cmd,
 		ProbesCount: 3,
 		Results: []globalping.ProbeMeasurement{
 			{
 				Result: globalping.ProbeResult{
-					Status: status,
+					Status: testStatus,
 				},
 			},
 			{
 				Result: globalping.ProbeResult{
-					Status: status,
+					Status: testStatus,
 				},
 			},
 			{
 				Result: globalping.ProbeResult{
-					Status: status,
+					Status: testStatus,
 				},
 			},
 		},
@@ -151,7 +151,7 @@ func createDefaultExpectedContext(cmd string) *view.Context {
 	}
 	ctx.History.Push(&view.HistoryItem{
 		Id:        measurementID1,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: defaultCurrentTime,
 	})
 	return ctx

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/icza/backscanner v0.0.0-20241124160932-dff01ac50250
-	github.com/jsdelivr/globalping-go v0.1.1-0.20251125110013-2813a850a61f
+	github.com/jsdelivr/globalping-go v0.2.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6 h1:8UsGZ2rr2ksmEru6lTo
 github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jsdelivr/globalping-go v0.1.1-0.20251125110013-2813a850a61f h1:1sro4RhnlRp6r1owDH0G4lcSOTqwl3Q40vVkVPN7vm8=
-github.com/jsdelivr/globalping-go v0.1.1-0.20251125110013-2813a850a61f/go.mod h1:LjoCP4GxjqXCK2exWRaqcs1kxdisnDphaT9lhN+kdIk=
+github.com/jsdelivr/globalping-go v0.2.0 h1:7qykXFjFMITyIMbL70XQytk0eMfsfEAEsYnPOkdy3iM=
+github.com/jsdelivr/globalping-go v0.2.0/go.mod h1:LjoCP4GxjqXCK2exWRaqcs1kxdisnDphaT9lhN+kdIk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/view/history.go
+++ b/view/history.go
@@ -14,7 +14,7 @@ type HistoryBuffer struct {
 type HistoryItem struct {
 	Id           string
 	Status       globalping.MeasurementStatus
-	ProbeStatus  []globalping.MeasurementStatus
+	ProbeStatus  []globalping.TestStatus
 	LinesPrinted int
 	StartedAt    time.Time
 	Stats        []*MeasurementStats

--- a/view/infinite.go
+++ b/view/infinite.go
@@ -24,7 +24,7 @@ var (
 )
 
 func (v *viewer) OutputInfinite(measurement *globalping.Measurement) error {
-	if measurement.Status != globalping.StatusInProgress && !isSomeTestFinished(measurement) {
+	if measurement.Status != globalping.MeasurementStatusInProgress && !isSomeTestFinished(measurement) {
 		return v.outputFailSummary(measurement)
 	}
 
@@ -69,7 +69,7 @@ func (v *viewer) outputStreamingPackets(m *globalping.Measurement) error {
 			v.printer.Println(parsedOutput.RawPacketLines[hm.LinesPrinted])
 			hm.LinesPrinted++
 		}
-		if m.Status != globalping.StatusInProgress {
+		if m.Status != globalping.MeasurementStatusInProgress {
 			v.ctx.AggregatedStats[0] = mergeMeasurementStats(*v.ctx.AggregatedStats[0], parsedOutput.Stats)
 		}
 	}
@@ -90,7 +90,7 @@ func (v *viewer) outputTableView(m *globalping.Measurement) error {
 	hm.Stats = newStats
 	output := *o + v.getAPICreditConsumptionInfo(width)
 	v.printer.AreaUpdate(&output)
-	if m.Status != globalping.StatusInProgress {
+	if m.Status != globalping.MeasurementStatusInProgress {
 		v.ctx.AggregatedStats = newAggregatedStats
 	}
 	return nil
@@ -106,7 +106,7 @@ func (v *viewer) outputFailSummary(m *globalping.Measurement) error {
 
 func isSomeTestFinished(m *globalping.Measurement) bool {
 	for i := range m.Results {
-		if m.Results[i].Result.Status == globalping.StatusFinished {
+		if m.Results[i].Result.Status == globalping.TestStatusFinished {
 			return true
 		}
 	}
@@ -194,7 +194,7 @@ func (v *viewer) generateTable(hm *HistoryItem, m *globalping.Measurement, areaW
 }
 
 func (v *viewer) aggregateConcurrentStats(completed *MeasurementStats, probeIndex int, excludeId string) *MeasurementStats {
-	inProgressStats := v.ctx.History.FilterByStatus(globalping.StatusInProgress)
+	inProgressStats := v.ctx.History.FilterByStatus(globalping.MeasurementStatusInProgress)
 	for i := range inProgressStats {
 		if inProgressStats[i].Id == excludeId {
 			continue

--- a/view/infinite_test.go
+++ b/view/infinite_test.go
@@ -28,8 +28,8 @@ func Test_OutputInfinite_SingleProbe_InProgress(t *testing.T) {
 	viewer := NewViewer(ctx, printer, utilsMock)
 
 	measurement := createPingMeasurement(measurementID1)
-	measurement.Status = globalping.StatusInProgress
-	measurement.Results[0].Result.Status = globalping.StatusInProgress
+	measurement.Status = globalping.MeasurementStatusInProgress
+	measurement.Results[0].Result.Status = globalping.TestStatusInProgress
 	measurement.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.`
 
 	err := viewer.OutputInfinite(measurement)
@@ -76,8 +76,8 @@ func Test_OutputInfinite_SingleProbe_InProgress(t *testing.T) {
 		Avg: 12.8, Max: 12.9, Time: 500, Tsum: 25.6, Tsum2: 327.7, Mdev: 0.0999}
 	assertMeasurementStats(t, expectedStats, hm.Stats[0])
 
-	measurement.Status = globalping.StatusFinished
-	measurement.Results[0].Result.Status = globalping.StatusFinished
+	measurement.Status = globalping.MeasurementStatusFinished
+	measurement.Results[0].Result.Status = globalping.TestStatusFinished
 	measurement.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=56 time=12.9 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=56 time=12.7 ms
@@ -134,8 +134,8 @@ rtt min/avg/max/mdev = 12.711/12.854/12.952/0.103 ms`
 
 func Test_OutputInfinite_SingleProbe_Failed(t *testing.T) {
 	measurement := createPingMeasurement(measurementID1)
-	measurement.Status = globalping.StatusFailed
-	measurement.Results[0].Result.Status = globalping.StatusFailed
+	measurement.Status = globalping.MeasurementStatusFinished
+	measurement.Results[0].Result.Status = globalping.TestStatusFailed
 	measurement.Results[0].Result.RawOutput = `ping: cdn.jsdelivr.net.xc: Name or service not known`
 
 	ctx := createDefaultContext("ping")
@@ -164,8 +164,8 @@ func Test_OutputInfinite_MultipleProbes_MultipleCalls(t *testing.T) {
 	utilsMock.EXPECT().Now().Return(defaultCurrentTime.Add(500 * time.Millisecond)).AnyTimes()
 
 	measurement := createPingMeasurement_MultipleProbes(measurementID1)
-	measurement.Status = globalping.StatusInProgress
-	measurement.Results[0].Result.Status = globalping.StatusInProgress
+	measurement.Status = globalping.MeasurementStatusInProgress
+	measurement.Results[0].Result.Status = globalping.TestStatusInProgress
 	measurement.Results[0].Result.RawOutput = `PING  (146.75.73.229) 56(84) bytes of data.`
 
 	ctx := createDefaultContext("ping")
@@ -211,8 +211,8 @@ Nuremberg, DE, EU, Hetzner Online GmbH (AS0)   |    1 |   0.00% |  4.07 ms |  4.
 	assertMeasurementStats(t, expectedStats[1], ctx.AggregatedStats[1])
 	assertMeasurementStats(t, expectedStats[2], ctx.AggregatedStats[2])
 
-	measurement.Status = globalping.StatusFinished
-	measurement.Results[0].Result.Status = globalping.StatusFinished
+	measurement.Status = globalping.MeasurementStatusFinished
+	measurement.Results[0].Result.Status = globalping.TestStatusFinished
 	measurement.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=17.6 ms
 no answer yet for icmp_seq=2
@@ -282,16 +282,16 @@ func Test_OutputInfinite_MultipleProbes_MultipleConcurrentCalls(t *testing.T) {
 
 	// Call 1
 	measurement1 := createPingMeasurement_MultipleProbes(measurementID1)
-	measurement1.Status = globalping.StatusInProgress
-	measurement1.Results[0].Result.Status = globalping.StatusInProgress
+	measurement1.Status = globalping.MeasurementStatusInProgress
+	measurement1.Results[0].Result.Status = globalping.TestStatusInProgress
 	measurement1.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=10 ms`
-	measurement1.Results[1].Result.Status = globalping.StatusInProgress
+	measurement1.Results[1].Result.Status = globalping.TestStatusInProgress
 	measurement1.Results[1].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.`
 
 	ctx := createDefaultContext("ping")
 	hm1 := ctx.History.Find(measurementID1)
-	hm1.Status = globalping.StatusInProgress
+	hm1.Status = globalping.MeasurementStatusInProgress
 	w := new(bytes.Buffer)
 	printer := NewPrinter(nil, w, w)
 	printer.DisableStyling()
@@ -308,15 +308,15 @@ Nuremberg, DE, EU, Hetzner Online GmbH (AS0)   |    1 |   0.00% |  4.07 ms |  4.
 
 	// Call 2
 	measurement2 := createPingMeasurement_MultipleProbes(measurementID2)
-	measurement2.Status = globalping.StatusInProgress
-	measurement2.Results[0].Result.Status = globalping.StatusInProgress
+	measurement2.Status = globalping.MeasurementStatusInProgress
+	measurement2.Results[0].Result.Status = globalping.TestStatusInProgress
 	measurement2.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.`
-	measurement2.Results[1].Result.Status = globalping.StatusInProgress
+	measurement2.Results[1].Result.Status = globalping.TestStatusInProgress
 	measurement2.Results[1].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=20 ms`
 	ctx.History.Push(&HistoryItem{
 		Id:        measurementID2,
-		Status:    globalping.StatusInProgress,
+		Status:    globalping.MeasurementStatusInProgress,
 		StartedAt: defaultCurrentTime.Add(1 * time.Millisecond),
 	})
 	ctx.MeasurementsCreated = 2
@@ -349,8 +349,8 @@ Consuming ~360 API credits/minute.
 	assert.NoError(t, err)
 
 	// Call 4
-	measurement1.Status = globalping.StatusFinished
-	measurement1.Results[0].Result.Status = globalping.StatusFinished
+	measurement1.Status = globalping.MeasurementStatusFinished
+	measurement1.Results[0].Result.Status = globalping.TestStatusFinished
 	measurement1.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=10 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=30 time=15 ms
@@ -359,7 +359,7 @@ Consuming ~360 API credits/minute.
 ---  ping statistics ---
 3 packets transmitted, 3 received, 0% packet loss, time 100ms
 rtt min/avg/max/mdev = 10/15/25/5 ms`
-	measurement1.Results[1].Result.Status = globalping.StatusFinished
+	measurement1.Results[1].Result.Status = globalping.TestStatusFinished
 	measurement1.Results[1].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=20 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=30 time=25 ms
@@ -368,7 +368,7 @@ rtt min/avg/max/mdev = 10/15/25/5 ms`
 ---  ping statistics ---
 3 packets transmitted, 3 received, 0% packet loss, time 200ms
 rtt min/avg/max/mdev = 20/25/30/5 ms`
-	hm1.Status = globalping.StatusFinished
+	hm1.Status = globalping.MeasurementStatusFinished
 
 	expectedOutput += "\033[5A\033[0J" +
 		`Location                                       | Sent |    Loss |     Last |      Min |      Avg |      Max
@@ -382,7 +382,7 @@ Consuming ~360 API credits/minute.
 	assert.NoError(t, err)
 
 	// Call 5
-	measurement2.Results[0].Result.Status = globalping.StatusFinished
+	measurement2.Results[0].Result.Status = globalping.TestStatusFinished
 	measurement2.Results[0].Result.RawOutput = `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=10 ms
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=2 ttl=30 time=15 ms
@@ -439,9 +439,9 @@ Nuremberg, DE, EU, Hetzner Online GmbH (AS0)   |    1 |   0.00% |  4.07 ms |  4.
 
 func Test_OutputInfinite_MultipleProbes_All_Failed(t *testing.T) {
 	measurement := createPingMeasurement_MultipleProbes(measurementID1)
-	measurement.Status = globalping.StatusFinished
+	measurement.Status = globalping.MeasurementStatusFinished
 	for i := range measurement.Results {
-		measurement.Results[i].Result.Status = globalping.StatusFailed
+		measurement.Results[i].Result.Status = globalping.TestStatusFailed
 		measurement.Results[i].Result.RawOutput = `ping: cdn.jsdelivr.net.xc: Name or service not known`
 	}
 
@@ -466,8 +466,8 @@ ping: cdn.jsdelivr.net.xc: Name or service not known
 
 func Test_OutputInfinite_SingleProbe_Offline(t *testing.T) {
 	measurement := createPingMeasurement(measurementID1)
-	measurement.Status = globalping.StatusFinished
-	measurement.Results[0].Result.Status = "offline"
+	measurement.Status = globalping.MeasurementStatusFinished
+	measurement.Results[0].Result.Status = globalping.TestStatusOffline
 	measurement.Results[0].Result.RawOutput = `This probe is currently offline. Please try again later.`
 
 	ctx := createDefaultContext("ping")

--- a/view/latency.go
+++ b/view/latency.go
@@ -17,7 +17,7 @@ func (v *viewer) OutputLatency(id string, measurement *globalping.Measurement) e
 		}
 
 		v.printer.ErrPrintln(v.getProbeInfo(&result))
-		if result.Result.Status != globalping.StatusFinished {
+		if result.Result.Status != globalping.TestStatusFinished {
 			v.printer.Println(result.Result.RawOutput)
 			continue
 		}

--- a/view/latency_test.go
+++ b/view/latency_test.go
@@ -23,7 +23,7 @@ func Test_Output_Latency_Ping(t *testing.T) {
 					Tags:      []string{"tag-1"},
 				},
 				Result: globalping.ProbeResult{
-					Status:   globalping.StatusFinished,
+					Status:   globalping.TestStatusFinished,
 					StatsRaw: json.RawMessage(`{"min":8,"avg":12,"max":20}`),
 				},
 			},
@@ -38,7 +38,7 @@ func Test_Output_Latency_Ping(t *testing.T) {
 					Tags:      []string{"tag B"},
 				},
 				Result: globalping.ProbeResult{
-					Status:   globalping.StatusFinished,
+					Status:   globalping.TestStatusFinished,
 					StatsRaw: json.RawMessage(`{"min":9,"avg":15,"max":22}`),
 				},
 			},
@@ -83,7 +83,7 @@ func Test_Output_Latency_Ping_StylingDisabled(t *testing.T) {
 					Tags:      []string{"tag"},
 				},
 				Result: globalping.ProbeResult{
-					Status:   globalping.StatusFinished,
+					Status:   globalping.TestStatusFinished,
 					StatsRaw: json.RawMessage(`{"min":8,"avg":12,"max":20}`),
 				},
 			},
@@ -127,7 +127,7 @@ func Test_Output_Latency_DNS(t *testing.T) {
 					Tags:      []string{"tag"},
 				},
 				Result: globalping.ProbeResult{
-					Status:     globalping.StatusFinished,
+					Status:     globalping.TestStatusFinished,
 					TimingsRaw: []byte(`{"total": 44}`),
 				},
 			},
@@ -165,7 +165,7 @@ func Test_Output_Latency_DNS_StylingDisabled(t *testing.T) {
 					Tags:      []string{"tag"},
 				},
 				Result: globalping.ProbeResult{
-					Status:     globalping.StatusFinished,
+					Status:     globalping.TestStatusFinished,
 					TimingsRaw: []byte(`{"total": 44}`),
 				},
 			},
@@ -207,7 +207,7 @@ func Test_Output_Latency_Http(t *testing.T) {
 					Tags:      []string{"tag"},
 				},
 				Result: globalping.ProbeResult{
-					Status:     globalping.StatusFinished,
+					Status:     globalping.TestStatusFinished,
 					TimingsRaw: []byte(`{"total": 44,"download":11,"firstByte":20,"dns":5,"tls":2,"tcp":4}`),
 				},
 			},
@@ -250,7 +250,7 @@ func Test_Output_Latency_Http_StylingDisabled(t *testing.T) {
 					Tags:      []string{"tag"},
 				},
 				Result: globalping.ProbeResult{
-					Status:     globalping.StatusFinished,
+					Status:     globalping.TestStatusFinished,
 					TimingsRaw: []byte(`{"total": 44,"download":11,"firstByte":20,"dns":5,"tls":2,"tcp":4}`),
 				},
 			},
@@ -298,7 +298,7 @@ func Test_Output_Latency_Offline(t *testing.T) {
 					Network:   "Network",
 				},
 				Result: globalping.ProbeResult{
-					Status:    globalping.MeasurementStatus("offline"),
+					Status:    globalping.TestStatusOffline,
 					RawOutput: "This probe is currently offline. Please try again later.",
 				},
 			},

--- a/view/summary_test.go
+++ b/view/summary_test.go
@@ -31,7 +31,7 @@ func Test_OutputSummary(t *testing.T) {
 		ctx.AggregatedStats[0].Time = 1000
 		hm := &HistoryItem{
 			Id:     measurementID2,
-			Status: globalping.StatusInProgress,
+			Status: globalping.MeasurementStatusInProgress,
 			Stats: []*MeasurementStats{
 				{Sent: 9, Rcv: 9, Lost: 0, Loss: 0, Last: 0.77, Min: 0.77, Avg: 0.77, Max: 0.77, Time: 1000, Tsum: 6.93, Tsum2: 5.3361},
 			},

--- a/view/utils_test.go
+++ b/view/utils_test.go
@@ -19,7 +19,7 @@ func createPingMeasurement(id string) *globalping.Measurement {
 	return &globalping.Measurement{
 		ID:          id,
 		Type:        "ping",
-		Status:      globalping.StatusFinished,
+		Status:      globalping.MeasurementStatusFinished,
 		CreatedAt:   "2024-01-18T14:09:41.250Z",
 		UpdatedAt:   "2024-01-18T14:09:41.488Z",
 		Target:      "cdn.jsdelivr.net",
@@ -37,7 +37,7 @@ func createPingMeasurement(id string) *globalping.Measurement {
 					Tags:      []string{"eyeball-network"},
 				},
 				Result: globalping.ProbeResult{
-					Status: globalping.StatusFinished,
+					Status: globalping.TestStatusFinished,
 					RawOutput: `PING jsdelivr.map.fastly.net (151.101.1.229) 56(84) bytes of data.
 64 bytes from 151.101.1.229 (151.101.1.229): icmp_seq=1 ttl=60 time=17.6 ms
 
@@ -58,7 +58,7 @@ func createPingMeasurement_MultipleProbes(id string) *globalping.Measurement {
 	return &globalping.Measurement{
 		ID:          id,
 		Type:        "ping",
-		Status:      globalping.StatusFinished,
+		Status:      globalping.MeasurementStatusFinished,
 		CreatedAt:   "2024-01-18T14:17:41.471Z",
 		UpdatedAt:   "2024-01-18T14:17:41.571Z",
 		Target:      "cdn.jsdelivr.net",
@@ -75,7 +75,7 @@ func createPingMeasurement_MultipleProbes(id string) *globalping.Measurement {
 					Tags:      []string{"datacenter-network"},
 				},
 				Result: globalping.ProbeResult{
-					Status: globalping.StatusFinished,
+					Status: globalping.TestStatusFinished,
 					RawOutput: `PING  (146.75.73.229) 56(84) bytes of data.
 64 bytes from 146.75.73.229 (146.75.73.229): icmp_seq=1 ttl=52 time=0.770 ms
 
@@ -99,7 +99,7 @@ rtt min/avg/max/mdev = 0.770/0.770/0.770/0.001 ms`,
 					Tags:      []string{"datacenter-network"},
 				},
 				Result: globalping.ProbeResult{
-					Status: globalping.StatusFinished,
+					Status: globalping.TestStatusFinished,
 					RawOutput: `PING  (104.16.85.20) 56(84) bytes of data.
 64 bytes from 104.16.85.20 (104.16.85.20): icmp_seq=1 ttl=55 time=5.46 ms
 
@@ -123,7 +123,7 @@ rtt min/avg/max/mdev = 5.457/5.457/5.457/0.002 ms`,
 					Tags:      []string{"datacenter-network"},
 				},
 				Result: globalping.ProbeResult{
-					Status: globalping.StatusFinished,
+					Status: globalping.TestStatusFinished,
 					RawOutput: `PING  (104.16.88.20) 56(84) bytes of data.
 64 bytes from 104.16.88.20 (104.16.88.20): icmp_seq=1 ttl=58 time=4.07 ms
 


### PR DESCRIPTION
Needed for https://github.com/jsdelivr/globalping-cli/issues/87