### PR TITLE
ci: use latest GoReleaser v2 version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: "v2.13.3"
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN_GORELEASER }}


### PR DESCRIPTION
An improved fix of https://github.com/jsdelivr/globalping-cli/issues/192 possible after https://github.com/goreleaser/goreleaser/releases/tag/v2.18.0