### PR TITLE
fix: improve error handling

### DIFF
--- a/api/probe/container_engine.go
+++ b/api/probe/container_engine.go
@@ -1,7 +1,8 @@
 package probe
 
 import (
-	"os"
+	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -14,18 +15,15 @@ const (
 	ContainerEnginePodman  ContainerEngine = "Podman"
 )
 
-func (*probe) DetectContainerEngine() (ContainerEngine, error) {
+func (p *probe) DetectContainerEngine() (ContainerEngine, error) {
 	// check if docker is installed
-	dockerInfoCmd := exec.Command("docker", "info")
-	dockerInfoCmd.Stderr = os.Stderr
-	dockerInfoErr := dockerInfoCmd.Run()
+	dockerInfo := p.execute("docker", "info")
 
-	if dockerInfoErr == nil {
+	if dockerInfo.err == nil {
 		// check if docker is aliased to podman
-		aliasCmd := exec.Command("type", "docker")
-		aliasResults, _ := aliasCmd.Output()
+		aliasResult := p.execute("type", "docker")
 
-		if strings.Contains(string(aliasResults), "podman") {
+		if aliasResult.err == nil && strings.Contains(strings.ToLower(string(aliasResult.stdout)), "podman") {
 			return ContainerEnginePodman, nil
 		}
 
@@ -33,13 +31,25 @@ func (*probe) DetectContainerEngine() (ContainerEngine, error) {
 	}
 
 	// check if podman is installed
-	podmanInfoCmd := exec.Command("podman", "info")
-	podmanInfoCmd.Stderr = os.Stderr
-	podmanInfoErr := podmanInfoCmd.Run()
+	podmanInfo := p.execute("podman", "info")
 
-	if podmanInfoErr == nil {
+	if podmanInfo.err == nil {
 		return ContainerEnginePodman, nil
 	}
 
-	return ContainerEngineUnknown, dockerInfoErr
+	return ContainerEngineUnknown, errors.Join(
+		containerEngineError("Docker", dockerInfo),
+		containerEngineError("Podman", podmanInfo),
+	)
+}
+
+func containerEngineError(name string, result executionResult) error {
+	err := executionError(result)
+	var execErr *exec.Error
+
+	if errors.As(result.err, &execErr) {
+		return fmt.Errorf("  %s: not installed or not available in PATH: %w", name, err)
+	}
+
+	return fmt.Errorf("  %s: installed but unavailable: %w", name, err)
 }

--- a/api/probe/probe.go
+++ b/api/probe/probe.go
@@ -2,9 +2,19 @@ package probe
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"strings"
+)
+
+var ErrContainerAlreadyInstalled = errors.New("the globalping-probe container is already installed on your system")
+
+const (
+	containerName       = "globalping-probe"
+	containerListFormat = "{{.Names}}\t{{.State}}\t{{.Status}}"
 )
 
 type Probe interface {
@@ -13,106 +23,145 @@ type Probe interface {
 	RunContainer(containerEngine ContainerEngine) error
 }
 
-type probe struct{}
+type executionResult struct {
+	stdout []byte
+	stderr []byte
+	err    error
+}
+
+type executor func(name string, args ...string) executionResult
+
+type probe struct {
+	execute executor
+	stdout  io.Writer
+	stderr  io.Writer
+}
 
 func NewProbe() Probe {
-	return &probe{}
+	return &probe{
+		execute: executeCommand,
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
+	}
 }
 
-func (*probe) InspectContainer(containerEngine ContainerEngine) error {
+func (p *probe) InspectContainer(containerEngine ContainerEngine) error {
+	var result executionResult
+
 	switch containerEngine {
 	case ContainerEngineDocker:
-		err := inspectContainerDocker()
-
-		if err != nil {
-			return err
-		}
+		result = p.execute("docker", "ps", "--all", "--format", containerListFormat)
 	case ContainerEnginePodman:
-		err := inspectContainerPodman()
-
-		if err != nil {
-			return err
-		}
+		result = p.execute("sudo", "podman", "ps", "--all", "--format", containerListFormat)
 	default:
 		return fmt.Errorf("unknown container engine %s", containerEngine)
 	}
 
-	return nil
+	if result.err != nil {
+		return fmt.Errorf("failed to query %s containers: %w", containerEngine, executionError(result))
+	}
+
+	err := classifyContainerList(string(result.stdout))
+
+	if err != nil && !errors.Is(err, ErrContainerAlreadyInstalled) {
+		return fmt.Errorf("failed to classify %s container list: %w", containerEngine, err)
+	}
+
+	return err
 }
 
-func (*probe) RunContainer(containerEngine ContainerEngine) error {
+func (p *probe) RunContainer(containerEngine ContainerEngine) error {
+	var result executionResult
+
 	switch containerEngine {
 	case ContainerEngineDocker:
-		err := runContainerDocker()
-
-		if err != nil {
-			return err
-		}
+		result = p.execute("docker", "run", "-d", "--log-driver", "local", "--network", "host", "--restart", "always", "--name", containerName, "globalping/globalping-probe")
 	case ContainerEnginePodman:
-		err := runContainerPodman()
-
-		if err != nil {
-			return err
-		}
+		result = p.execute("sudo", "podman", "run", "--cap-add=NET_RAW", "-d", "--network", "host", "--restart=always", "--name", containerName, "globalping/globalping-probe")
 	default:
 		return fmt.Errorf("unknown container engine %s", containerEngine)
 	}
 
-	return nil
-}
+	if result.err != nil {
+		return fmt.Errorf("failed to run %s container: %w", containerEngine, executionError(result))
+	}
 
-func inspectContainerDocker() error {
-	cmd := exec.Command("docker", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
-	containerStatus, err := cmd.Output()
+	if p.stdout != nil {
+		_, _ = p.stdout.Write(result.stdout)
+	}
 
-	if err == nil {
-		containerStatusStr := string(bytes.TrimSpace(containerStatus))
-
-		return fmt.Errorf("the globalping-probe container is already installed on your system. Current status: %s", containerStatusStr)
+	if p.stderr != nil {
+		_, _ = p.stderr.Write(result.stderr)
 	}
 
 	return nil
 }
 
-func inspectContainerPodman() error {
-	cmd := exec.Command("sudo", "podman", "inspect", "globalping-probe", "-f", "{{.State.Status}}")
-	containerStatus, err := cmd.Output()
+func executeCommand(name string, args ...string) executionResult {
+	cmd := exec.Command(name, args...)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
 
-	if err == nil {
-		containerStatusStr := string(bytes.TrimSpace(containerStatus))
+	return executionResult{
+		stdout: stdout.Bytes(),
+		stderr: stderr.Bytes(),
+		err:    err,
+	}
+}
 
-		if containerStatusStr == "" {
-			// false positive as podmain keeps container info after deletion
-			return nil
+func executionError(result executionResult) error {
+	details := bytes.TrimSpace(result.stderr)
+
+	if len(details) == 0 {
+		details = bytes.TrimSpace(result.stdout)
+	}
+
+	if len(details) == 0 {
+		return result.err
+	}
+
+	detailText := strings.ReplaceAll(string(details), "\r\n", "\n")
+	detailText = strings.ReplaceAll(detailText, "\r", "\n")
+	detailText = strings.ReplaceAll(detailText, "\n", "; ")
+
+	return fmt.Errorf("%w: %s", result.err, detailText)
+}
+
+func classifyContainerList(output string) error {
+	output = strings.TrimSpace(output)
+
+	if output == "" {
+		return nil
+	}
+
+	installedRows := make([][]string, 0, 1)
+
+	for line := range strings.SplitSeq(output, "\n") {
+		parts := strings.SplitN(strings.TrimSuffix(line, "\r"), "\t", 3)
+
+		if len(parts) != 3 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" || strings.TrimSpace(parts[2]) == "" {
+			return fmt.Errorf("malformed container list output: %q", line)
 		}
 
-		return fmt.Errorf("the globalping-probe container is already installed on your system. Current status: %s", containerStatusStr)
+		if strings.TrimSpace(parts[0]) == containerName {
+			installedRows = append(installedRows, parts)
+		}
 	}
 
-	return nil
-}
-
-func runContainerDocker() error {
-	cmd := exec.Command("docker", "run", "-d", "--log-driver", "local", "--network", "host", "--restart", "always", "--name", "globalping-probe", "globalping/globalping-probe")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-
-	if err != nil {
-		return fmt.Errorf("failed to run container: %w", err)
+	if len(installedRows) > 1 {
+		return fmt.Errorf("ambiguous container list output: found %d %s rows", len(installedRows), containerName)
 	}
 
-	return nil
-}
-
-func runContainerPodman() error {
-	cmd := exec.Command("sudo", "podman", "run", "--cap-add=NET_RAW", "-d", "--network", "host", "--restart=always", "--name", "globalping-probe", "globalping/globalping-probe")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-
-	if err != nil {
-		return fmt.Errorf("failed to run container: %w", err)
+	if len(installedRows) == 1 {
+		return fmt.Errorf(
+			"%w. Current state: %s; status: %s",
+			ErrContainerAlreadyInstalled,
+			strings.TrimSpace(installedRows[0][1]),
+			strings.TrimSpace(installedRows[0][2]),
+		)
 	}
 
 	return nil

--- a/api/probe/probe_test.go
+++ b/api/probe/probe_test.go
@@ -1,0 +1,235 @@
+package probe
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type expectedExecution struct {
+	name   string
+	args   []string
+	result executionResult
+}
+
+func fakeExecutor(t *testing.T, expected []expectedExecution) executor {
+	t.Helper()
+
+	next := 0
+	t.Cleanup(func() {
+		assert.Equal(t, len(expected), next, "not all expected commands were executed")
+	})
+
+	return func(name string, args ...string) executionResult {
+		t.Helper()
+		require.Less(t, next, len(expected), "unexpected command: %s %v", name, args)
+		call := expected[next]
+		next++
+		assert.Equal(t, call.name, name)
+		assert.Equal(t, call.args, args)
+
+		return call.result
+	}
+}
+
+func TestDetectContainerEngine(t *testing.T) {
+	t.Run("docker", func(t *testing.T) {
+		p := &probe{execute: fakeExecutor(t, []expectedExecution{
+			{name: "docker", args: []string{"info"}},
+			{name: "type", args: []string{"docker"}, result: executionResult{stdout: []byte("docker is /usr/local/bin/docker\n")}},
+		})}
+
+		engine, err := p.DetectContainerEngine()
+
+		require.NoError(t, err)
+		assert.Equal(t, ContainerEngineDocker, engine)
+	})
+
+	t.Run("docker alias for podman", func(t *testing.T) {
+		p := &probe{execute: fakeExecutor(t, []expectedExecution{
+			{name: "docker", args: []string{"info"}},
+			{name: "type", args: []string{"docker"}, result: executionResult{stdout: []byte("docker is aliased to podman")}},
+		})}
+
+		engine, err := p.DetectContainerEngine()
+
+		require.NoError(t, err)
+		assert.Equal(t, ContainerEnginePodman, engine)
+	})
+
+	t.Run("podman fallback", func(t *testing.T) {
+		dockerErr := errors.New("docker unavailable")
+		p := &probe{execute: fakeExecutor(t, []expectedExecution{
+			{name: "docker", args: []string{"info"}, result: executionResult{err: dockerErr}},
+			{name: "podman", args: []string{"info"}},
+		})}
+
+		engine, err := p.DetectContainerEngine()
+
+		require.NoError(t, err)
+		assert.Equal(t, ContainerEnginePodman, engine)
+	})
+
+	t.Run("both fail with diagnostics", func(t *testing.T) {
+		dockerErr := errors.New("docker exit")
+		podmanErr := &exec.Error{Name: "podman", Err: exec.ErrNotFound}
+		p := &probe{execute: fakeExecutor(t, []expectedExecution{
+			{name: "docker", args: []string{"info"}, result: executionResult{stderr: []byte("cannot connect to docker\nerrors pretty printing info\n"), err: dockerErr}},
+			{name: "podman", args: []string{"info"}, result: executionResult{err: podmanErr}},
+		})}
+
+		engine, err := p.DetectContainerEngine()
+
+		assert.Equal(t, ContainerEngineUnknown, engine)
+		assert.ErrorIs(t, err, dockerErr)
+		assert.ErrorIs(t, err, podmanErr)
+		assert.EqualError(t, err, "  Docker: installed but unavailable: docker exit: cannot connect to docker; errors pretty printing info\n"+
+			"  Podman: not installed or not available in PATH: exec: \"podman\": executable file not found in $PATH")
+	})
+}
+
+func TestProbeInspectContainer(t *testing.T) {
+	queryErr := errors.New("exit status 1")
+	tests := []struct {
+		name        string
+		engine      ContainerEngine
+		command     string
+		args        []string
+		result      executionResult
+		errorIs     error
+		errorText   string
+		wantNoError bool
+	}{
+		{
+			name:        "docker absent",
+			engine:      ContainerEngineDocker,
+			command:     "docker",
+			args:        []string{"ps", "--all", "--format", containerListFormat},
+			result:      executionResult{stdout: []byte("another-container\trunning\tUp 3 hours\n")},
+			wantNoError: true,
+		},
+		{
+			name:      "podman already installed",
+			engine:    ContainerEnginePodman,
+			command:   "sudo",
+			args:      []string{"podman", "ps", "--all", "--format", containerListFormat},
+			result:    executionResult{stdout: []byte("globalping-probe\texited\tExited (1) 2 minutes ago\n")},
+			errorIs:   ErrContainerAlreadyInstalled,
+			errorText: "Current state: exited; status: Exited (1) 2 minutes ago",
+		},
+		{
+			name:      "query failure",
+			engine:    ContainerEngineDocker,
+			command:   "docker",
+			args:      []string{"ps", "--all", "--format", containerListFormat},
+			result:    executionResult{stderr: []byte("permission denied\n"), err: queryErr},
+			errorIs:   queryErr,
+			errorText: "permission denied",
+		},
+		{
+			name:      "malformed output",
+			engine:    ContainerEngineDocker,
+			command:   "docker",
+			args:      []string{"ps", "--all", "--format", containerListFormat},
+			result:    executionResult{stdout: []byte("globalping-probe running Up 3 hours\n")},
+			errorText: "malformed container list output",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &probe{execute: fakeExecutor(t, []expectedExecution{{name: tt.command, args: tt.args, result: tt.result}})}
+
+			err := p.InspectContainer(tt.engine)
+
+			if tt.wantNoError {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+
+			if tt.errorIs != nil {
+				assert.ErrorIs(t, err, tt.errorIs)
+			}
+
+			assert.ErrorContains(t, err, tt.errorText)
+		})
+	}
+}
+
+func TestClassifyContainerListRequiresExactUnambiguousRows(t *testing.T) {
+	assert.NoError(t, classifyContainerList("globalping-probe-helper\trunning\tUp 2 hours\n"))
+	assert.ErrorContains(t, classifyContainerList("globalping-probe\trunning\tUp 2 hours\nglobalping-probe\texited\tExited (0)\n"), "ambiguous")
+	assert.ErrorContains(t, classifyContainerList("globalping-probe\t\tUp 2 hours\n"), "malformed")
+}
+
+func TestProbeRunContainerOutput(t *testing.T) {
+	t.Run("success forwards captured streams", func(t *testing.T) {
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		p := &probe{
+			execute: fakeExecutor(t, []expectedExecution{{
+				name:   "docker",
+				args:   []string{"run", "-d", "--log-driver", "local", "--network", "host", "--restart", "always", "--name", containerName, "globalping/globalping-probe"},
+				result: executionResult{stdout: []byte("container-id\n"), stderr: []byte("warning\n")},
+			}}),
+			stdout: stdout,
+			stderr: stderr,
+		}
+
+		require.NoError(t, p.RunContainer(ContainerEngineDocker))
+		assert.Equal(t, "container-id\n", stdout.String())
+		assert.Equal(t, "warning\n", stderr.String())
+	})
+
+	t.Run("failure returns stderr without forwarding streams", func(t *testing.T) {
+		runErr := errors.New("exit status 125")
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		p := &probe{
+			execute: fakeExecutor(t, []expectedExecution{{
+				name:   "sudo",
+				args:   []string{"podman", "run", "--cap-add=NET_RAW", "-d", "--network", "host", "--restart=always", "--name", containerName, "globalping/globalping-probe"},
+				result: executionResult{stdout: []byte("partial-id\n"), stderr: []byte("image pull failed\n"), err: runErr},
+			}}),
+			stdout: stdout,
+			stderr: stderr,
+		}
+
+		err := p.RunContainer(ContainerEnginePodman)
+
+		assert.ErrorIs(t, err, runErr)
+		assert.ErrorContains(t, err, "image pull failed")
+		assert.Empty(t, stdout.String())
+		assert.Empty(t, stderr.String())
+	})
+
+	t.Run("failure falls back to stdout diagnostics", func(t *testing.T) {
+		runErr := errors.New("exit status 125")
+		p := &probe{execute: fakeExecutor(t, []expectedExecution{{
+			name:   "docker",
+			args:   []string{"run", "-d", "--log-driver", "local", "--network", "host", "--restart", "always", "--name", containerName, "globalping/globalping-probe"},
+			result: executionResult{stdout: []byte("daemon unavailable\n"), err: runErr},
+		}})}
+
+		err := p.RunContainer(ContainerEngineDocker)
+
+		assert.ErrorIs(t, err, runErr)
+		assert.ErrorContains(t, err, "daemon unavailable")
+	})
+}
+
+func TestProbeRejectsUnknownContainerEngine(t *testing.T) {
+	p := &probe{execute: func(string, ...string) executionResult {
+		panic("executor must not be called")
+	}}
+
+	assert.EqualError(t, p.InspectContainer(ContainerEngineUnknown), "unknown container engine Unknown")
+	assert.EqualError(t, p.RunContainer(ContainerEngineUnknown), "unknown container engine Unknown")
+}

--- a/api/probe/probe_test.go
+++ b/api/probe/probe_test.go
@@ -40,7 +40,7 @@ func TestDetectContainerEngine(t *testing.T) {
 	t.Run("docker", func(t *testing.T) {
 		p := &probe{execute: fakeExecutor(t, []expectedExecution{
 			{name: "docker", args: []string{"info"}},
-			{name: "type", args: []string{"docker"}, result: executionResult{stdout: []byte("docker is /usr/local/bin/docker\n")}},
+			{name: "type", args: []string{"docker"}, result: executionResult{stdout: []byte("docker")}},
 		})}
 
 		engine, err := p.DetectContainerEngine()
@@ -88,7 +88,7 @@ func TestDetectContainerEngine(t *testing.T) {
 		assert.ErrorIs(t, err, dockerErr)
 		assert.ErrorIs(t, err, podmanErr)
 		assert.EqualError(t, err, "  Docker: installed but unavailable: docker exit: cannot connect to docker; errors pretty printing info\n"+
-			"  Podman: not installed or not available in PATH: exec: \"podman\": executable file not found in $PATH")
+			"  Podman: not installed or not available in PATH: "+podmanErr.Error())
 	})
 }
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -11,7 +11,7 @@ import (
 
 func (r *Root) initHistory() {
 	historyCmd := &cobra.Command{
-		Run:   r.RunHistory,
+		RunE:  r.RunHistory,
 		Use:   "history",
 		Short: "Display the measurement history of your current session",
 		Long: `Display the measurement history of your current session.
@@ -34,7 +34,7 @@ Examples:
 	r.Cmd.AddCommand(historyCmd)
 }
 
-func (r *Root) RunHistory(_ *cobra.Command, _ []string) {
+func (r *Root) RunHistory(_ *cobra.Command, _ []string) error {
 	limit := 0
 
 	if r.ctx.Head > 0 {
@@ -46,20 +46,22 @@ func (r *Root) RunHistory(_ *cobra.Command, _ []string) {
 	items, err := r.storage.GetHistory(limit)
 
 	if err != nil {
-		r.printer.Println(err)
+		r.Cmd.SilenceUsage = true
 
-		return
+		return fmt.Errorf("failed to get history: %w", err)
 	}
 
 	if len(items) == 0 {
 		r.printer.Println("No history items found")
 
-		return
+		return nil
 	}
 
 	for _, item := range items {
 		r.printer.Println(item)
 	}
+
+	return nil
 }
 
 func (r *Root) UpdateHistory() error {

--- a/cmd/history_test.go
+++ b/cmd/history_test.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	utilsMocks "github.com/jsdelivr/globalping-cli/mocks/utils"
+	"github.com/jsdelivr/globalping-cli/storage"
 	"github.com/jsdelivr/globalping-cli/view"
 	"github.com/jsdelivr/globalping-go"
 	"github.com/stretchr/testify/assert"
@@ -84,4 +87,41 @@ func Test_Execute_History_Default(t *testing.T) {
 		createDefaultExpectedHistoryItem("1", "ping jsdelivr.com", measurementID1)+"\n"+
 			createDefaultExpectedHistoryItem("-", "ping jsdelivr.com from last", measurementID2)+"\n",
 		w.String())
+}
+
+func Test_Execute_History_Empty(t *testing.T) {
+	utilsMock := utilsMocks.NewMockUtils(gomock.NewController(t))
+	_storage := createDefaultTestStorage(t, utilsMock)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, utilsMock, nil, nil, _storage)
+	os.Args = []string{"globalping", "history"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.NoError(t, err)
+	assert.Equal(t, "No history items found\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func Test_Execute_History_ForwardScannerError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	utilsMock := utilsMocks.NewMockUtils(ctrl)
+	_storage := createDefaultTestStorage(t, utilsMock)
+	assert.NoError(t, _storage.SaveCommandToHistory("1", defaultCurrentTime.Unix(), measurementID1, "command1"))
+	assert.NoError(t, _storage.SaveCommandToHistory("2", defaultCurrentTime.Unix(), measurementID2, strings.Repeat("x", bufio.MaxScanTokenSize)))
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, utilsMock, nil, nil, _storage)
+	os.Args = []string{"globalping", "history"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, storage.ErrReadHistory)
+	assert.ErrorContains(t, err, "token too long")
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+	assert.Contains(t, stderr.String(), "failed to get history")
+	assert.Contains(t, stderr.String(), "token too long")
 }

--- a/cmd/install_probe.go
+++ b/cmd/install_probe.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 
 	"github.com/jsdelivr/globalping-cli/api/probe"
 	"github.com/spf13/cobra"
@@ -12,20 +14,19 @@ func (r *Root) initInstallProbe() {
 		Use:   "install-probe",
 		Short: "Join the Globalping network by running a probe",
 		Long:  `The install-probe command downloads and runs the Globalping probe in a Docker container on your machine. Requires you to have Docker installed.`,
-		Run:   r.RunInstallProbe,
+		RunE:  r.RunInstallProbe,
 	}
 
 	r.Cmd.AddCommand(installProbeCmd)
 }
 
-func (r *Root) RunInstallProbe(_ *cobra.Command, _ []string) {
+func (r *Root) RunInstallProbe(_ *cobra.Command, _ []string) error {
 	containerEngine, err := r.probe.DetectContainerEngine()
 
 	if err != nil {
-		r.printer.Printf("docker info command failed: %v\n\n", err)
-		r.printer.Println("Docker was not detected on your system and it is required to run the Globalping probe. Please install Docker and try again.")
+		r.Cmd.SilenceUsage = true
 
-		return
+		return fmt.Errorf("no working container engine was detected; ensure Docker Desktop or Podman is installed and running:\n%w", err)
 	}
 
 	r.printer.Printf("Detected container engine: %s\n\n", containerEngine)
@@ -33,25 +34,37 @@ func (r *Root) RunInstallProbe(_ *cobra.Command, _ []string) {
 	err = r.probe.InspectContainer(containerEngine)
 
 	if err != nil {
-		r.printer.Println(err)
+		if errors.Is(err, probe.ErrContainerAlreadyInstalled) {
+			r.printer.Println(err)
 
-		return
+			return nil
+		}
+
+		r.Cmd.SilenceUsage = true
+
+		return err
 	}
 
-	ok := r.askUser(containerPullMessage(containerEngine))
+	ok, err := r.askUser(containerPullMessage(containerEngine))
+
+	if err != nil {
+		r.Cmd.SilenceUsage = true
+
+		return err
+	}
 
 	if !ok {
 		r.printer.Println("You can also run a probe manually, check our GitHub for detailed instructions. Exited without changes.")
 
-		return
+		return nil
 	}
 
 	err = r.probe.RunContainer(containerEngine)
 
 	if err != nil {
-		r.printer.Println(err)
+		r.Cmd.SilenceUsage = true
 
-		return
+		return err
 	}
 
 	r.printer.Printf("The Globalping probe started successfully. Thank you for joining our community! \n")
@@ -59,6 +72,8 @@ func (r *Root) RunInstallProbe(_ *cobra.Command, _ []string) {
 	if containerEngine == probe.ContainerEnginePodman {
 		r.printer.Printf("When you are using Podman, you also need to install a service to make sure the container starts on boot. Please see our instructions here: https://github.com/jsdelivr/globalping-probe/blob/master/README.md#podman-alternative\n")
 	}
+
+	return nil
 }
 
 func containerPullMessage(containerEngine probe.ContainerEngine) string {
@@ -73,7 +88,7 @@ func containerPullMessage(containerEngine probe.ContainerEngine) string {
 	return pre + mid + post
 }
 
-func (r *Root) askUser(s string) bool {
+func (r *Root) askUser(s string) (bool, error) {
 	r.printer.Printf("%s [Y/n] ", s)
 
 	reader := bufio.NewReader(r.printer.InReader)
@@ -81,17 +96,15 @@ func (r *Root) askUser(s string) bool {
 	c, _, err := reader.ReadRune()
 
 	if err != nil {
-		r.printer.Printf("failed to read character %v", err)
-
-		return false
+		return false, fmt.Errorf("failed to read character: %w", err)
 	}
 
 	switch c {
 	case 'Y':
-		return true
+		return true, nil
 	case '\n':
-		return true
+		return true, nil
 	default:
-		return false
+		return false, nil
 	}
 }

--- a/cmd/install_probe_test.go
+++ b/cmd/install_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -54,8 +55,9 @@ Please confirm to pull and run our Docker container (globalping/globalping-probe
 func Test_Execute_Install_Probe_DetectionFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	probeMock := apiMocks.NewMockProbe(ctrl)
+	podmanErr := &exec.Error{Name: "podman", Err: exec.ErrNotFound}
 	detectErr := errors.New("  Docker: installed but unavailable: exit status 1: request returned 500; errors pretty printing info\n" +
-		"  Podman: not installed or not available in PATH: executable file not found in $PATH")
+		"  Podman: not installed or not available in PATH: " + podmanErr.Error())
 	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineUnknown, detectErr)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/cmd/install_probe_test.go
+++ b/cmd/install_probe_test.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jsdelivr/globalping-cli/api/probe"
@@ -45,4 +49,142 @@ Please confirm to pull and run our Docker container (globalping/globalping-probe
 		RunSessionStartedAt: defaultCurrentTime,
 	}
 	assert.Equal(t, expectedCtx, ctx)
+}
+
+func Test_Execute_Install_Probe_DetectionFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	detectErr := errors.New("  Docker: installed but unavailable: exit status 1: request returned 500; errors pretty printing info\n" +
+		"  Podman: not installed or not available in PATH: executable file not found in $PATH")
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineUnknown, detectErr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, detectErr)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "Error: no working container engine was detected; ensure Docker Desktop or Podman is installed and running:\n"+
+		detectErr.Error()+"\n", stderr.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+}
+
+func Test_Execute_Install_Probe_AlreadyInstalled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	installedErr := fmt.Errorf("%w. Current state: running; status: Up 3 hours", probe.ErrContainerAlreadyInstalled)
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineDocker, nil)
+	probeMock.EXPECT().InspectContainer(probe.ContainerEngineDocker).Return(installedErr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Detected container engine: Docker\n\n"+installedErr.Error()+"\n", stdout.String())
+	assert.Empty(t, stderr.String())
+	assert.False(t, root.Cmd.SilenceUsage)
+}
+
+func Test_Execute_Install_Probe_PresenceFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	presenceErr := errors.New("failed to query containers")
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineDocker, nil)
+	probeMock.EXPECT().InspectContainer(probe.ContainerEngineDocker).Return(presenceErr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, presenceErr)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Equal(t, "Detected container engine: Docker\n\n", stdout.String())
+	assert.Equal(t, "Error: failed to query containers\n", stderr.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+}
+
+func Test_Execute_Install_Probe_PromptFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineDocker, nil)
+	probeMock.EXPECT().InspectContainer(probe.ContainerEngineDocker).Return(nil)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(bytes.NewReader(nil), stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, io.EOF)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Contains(t, stdout.String(), "[Y/n] ")
+	assert.Equal(t, "Error: failed to read character: EOF\n", stderr.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+}
+
+func Test_Execute_Install_Probe_Declined(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineDocker, nil)
+	probeMock.EXPECT().InspectContainer(probe.ContainerEngineDocker).Return(nil)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(bytes.NewBufferString("n\n"), stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Exited without changes.\n")
+	assert.Empty(t, stderr.String())
+}
+
+func Test_Execute_Install_Probe_RunFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	runErr := errors.New("container run failed: image pull denied")
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEngineDocker, nil)
+	probeMock.EXPECT().InspectContainer(probe.ContainerEngineDocker).Return(nil)
+	probeMock.EXPECT().RunContainer(probe.ContainerEngineDocker).Return(runErr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(bytes.NewBufferString("Y\n"), stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, runErr)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.NotContains(t, stdout.String(), "started successfully")
+	assert.Equal(t, "Error: container run failed: image pull denied\n", stderr.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+}
+
+func Test_Execute_Install_Probe_PodmanSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	probeMock := apiMocks.NewMockProbe(ctrl)
+	probeMock.EXPECT().DetectContainerEngine().Return(probe.ContainerEnginePodman, nil)
+	probeMock.EXPECT().InspectContainer(probe.ContainerEnginePodman).Return(nil)
+	probeMock.EXPECT().RunContainer(probe.ContainerEnginePodman).Return(nil)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(bytes.NewBufferString("\n"), stdout, stderr), createDefaultContext(), nil, nil, nil, probeMock, nil)
+	os.Args = []string{"globalping", "install-probe"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Detected container engine: Podman")
+	assert.Contains(t, stdout.String(), "sudo podman")
+	assert.Contains(t, stdout.String(), "The Globalping probe started successfully.")
+	assert.Contains(t, stdout.String(), "install a service")
+	assert.Empty(t, stderr.String())
 }

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -30,9 +30,7 @@ func (r *Root) RunLimits(cmd *cobra.Command, _ []string) error {
 		var authorizeErr *api.AuthorizeError
 
 		if !errors.As(err, &authorizeErr) || authorizeErr.ErrorType != api.ErrTypeNotAuthorized {
-			r.Cmd.SilenceUsage = true
-
-			return err
+			r.printer.ErrPrintf("Warning: failed to retrieve authentication details: %s\n", err)
 		}
 	}
 
@@ -54,7 +52,11 @@ func (r *Root) RunLimits(cmd *cobra.Command, _ []string) error {
 	t := limits.RateLimits.Measurements.Create.Type
 
 	if t == globalping.CreateLimitTypeUser {
-		r.printer.Printf("Authentication: token (%s)\n\n", username)
+		if username == "" {
+			r.printer.Printf("Authentication: token\n\n")
+		} else {
+			r.printer.Printf("Authentication: token (%s)\n\n", username)
+		}
 	} else {
 		r.printer.Printf("Authentication: IP address\n\n")
 	}

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"errors"
+
+	"github.com/jsdelivr/globalping-cli/api"
 	"github.com/jsdelivr/globalping-cli/utils"
 	"github.com/jsdelivr/globalping-go"
 	"github.com/spf13/cobra"
@@ -20,8 +23,18 @@ func (r *Root) initLimits() {
 func (r *Root) RunLimits(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
-	introspection, _ := r.client.TokenIntrospection(ctx, "")
+	introspection, err := r.client.TokenIntrospection(ctx, "")
 	username := ""
+
+	if err != nil {
+		var authorizeErr *api.AuthorizeError
+
+		if !errors.As(err, &authorizeErr) || authorizeErr.ErrorType != api.ErrTypeNotAuthorized {
+			r.Cmd.SilenceUsage = true
+
+			return err
+		}
+	}
 
 	if introspection != nil {
 		username = introspection.Username
@@ -30,6 +43,8 @@ func (r *Root) RunLimits(cmd *cobra.Command, _ []string) error {
 	limits, err := r.client.Limits(ctx)
 
 	if err != nil {
+		r.Cmd.SilenceUsage = true
+
 		return err
 	}
 

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jsdelivr/globalping-cli/api"
@@ -116,7 +119,10 @@ func Test_Limits_IP(t *testing.T) {
 
 	gbMock := apiMocks.NewMockClient(ctrl)
 
-	gbMock.EXPECT().TokenIntrospection(t.Context(), "").Return(nil, &api.AuthorizeError{Description: "client is not authorized"})
+	gbMock.EXPECT().TokenIntrospection(t.Context(), "").Return(nil, fmt.Errorf("token introspection: %w", &api.AuthorizeError{
+		ErrorType:   api.ErrTypeNotAuthorized,
+		Description: "client is not authorized",
+	}))
 	gbMock.EXPECT().Limits(t.Context()).Return(&globalping.LimitsResponse{
 		RateLimits: globalping.RateLimits{
 			Measurements: globalping.MeasurementsLimits{
@@ -148,4 +154,46 @@ Creating measurements:
  - 150 consumed, 350 remaining
  - resets in 10 minutes
 `, w.String())
+}
+
+func Test_Limits_UnexpectedIntrospectionError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	gbMock := apiMocks.NewMockClient(ctrl)
+	introspectionErr := errors.New("introspection network error")
+	gbMock.EXPECT().TokenIntrospection(t.Context(), "").Return(nil, introspectionErr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, nil, gbMock, nil, nil)
+	os.Args = []string{"globalping", "limits"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, introspectionErr)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "Error: introspection network error\n", stderr.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+}
+
+func Test_Limits_ServiceError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	gbMock := apiMocks.NewMockClient(ctrl)
+	limitsErr := errors.New("limits service error")
+	gbMock.EXPECT().TokenIntrospection(t.Context(), "").Return(&api.IntrospectionResponse{
+		Active:   true,
+		Username: "test",
+	}, nil)
+	gbMock.EXPECT().Limits(t.Context()).Return(nil, limitsErr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, nil, gbMock, nil, nil)
+	os.Args = []string{"globalping", "limits"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, limitsErr)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "Error: limits service error\n", stderr.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
 }

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -161,6 +161,20 @@ func Test_Limits_UnexpectedIntrospectionError(t *testing.T) {
 	gbMock := apiMocks.NewMockClient(ctrl)
 	introspectionErr := errors.New("introspection network error")
 	gbMock.EXPECT().TokenIntrospection(t.Context(), "").Return(nil, introspectionErr)
+	gbMock.EXPECT().Limits(t.Context()).Return(&globalping.LimitsResponse{
+		RateLimits: globalping.RateLimits{
+			Measurements: globalping.MeasurementsLimits{
+				Create: globalping.MeasurementsCreateLimits{
+					Type:      "user",
+					Limit:     500,
+					Remaining: 350,
+				},
+			},
+		},
+		Credits: globalping.CreditLimits{
+			Remaining: 1000,
+		},
+	}, nil)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	root := NewRoot(view.NewPrinter(nil, stdout, stderr), createDefaultContext(), nil, nil, gbMock, nil, nil)
@@ -168,11 +182,18 @@ func Test_Limits_UnexpectedIntrospectionError(t *testing.T) {
 
 	err := root.Cmd.ExecuteContext(t.Context())
 
-	assert.ErrorIs(t, err, introspectionErr)
-	assert.True(t, root.Cmd.SilenceUsage)
-	assert.Empty(t, stdout.String())
-	assert.Equal(t, "Error: introspection network error\n", stderr.String())
-	assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+	assert.NoError(t, err)
+	assert.False(t, root.Cmd.SilenceUsage)
+	assert.Equal(t, `Authentication: token
+
+Creating measurements:
+ - 500 tests per hour
+ - 150 consumed, 350 remaining
+
+Credits:
+ - 1000 credits remaining (may be used to create measurements above the hourly limits)
+`, stdout.String())
+	assert.Equal(t, "Warning: failed to retrieve authentication details: introspection network error\n", stderr.String())
 }
 
 func Test_Limits_ServiceError(t *testing.T) {

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -70,6 +70,39 @@ func Test_Execute_Ping_Default(t *testing.T) {
 	assert.Equal(t, expectedHistoryItems, items)
 }
 
+func Test_Execute_Ping_FiniteLatencyOutputError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	expectedOpts := createDefaultMeasurementCreate("ping")
+	expectedOpts.Locations = globalping.LocationOptions{{Magic: "world"}}
+	expectedResponse := createDefaultMeasurementCreateResponse()
+	expectedMeasurement := createDefaultMeasurement("ping")
+	outputErr := errors.New("latency output failed")
+
+	gbMock := apiMocks.NewMockClient(ctrl)
+	gbMock.EXPECT().CreateMeasurement(t.Context(), expectedOpts).Return(expectedResponse, nil)
+	gbMock.EXPECT().AwaitMeasurement(t.Context(), expectedResponse.ID).Return(expectedMeasurement, nil)
+
+	viewerMock := viewMocks.NewMockViewer(ctrl)
+	viewerMock.EXPECT().OutputLatency(measurementID1, expectedMeasurement).Return(outputErr)
+
+	utilsMock := utilsMocks.NewMockUtils(ctrl)
+	utilsMock.EXPECT().Now().Return(defaultCurrentTime).AnyTimes()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := createDefaultContext()
+	_storage := createDefaultTestStorage(t, utilsMock)
+	root := NewRoot(view.NewPrinter(nil, stdout, stderr), ctx, viewerMock, utilsMock, gbMock, nil, _storage)
+	os.Args = []string{"globalping", "ping", "jsdelivr.com", "--latency"}
+
+	err := root.Cmd.ExecuteContext(t.Context())
+
+	assert.ErrorIs(t, err, outputErr)
+	assert.True(t, root.Cmd.SilenceUsage)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "Error: latency output failed\n", stderr.String())
+}
+
 func Test_Execute_Ping_Locations_And_Session(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/storage/history.go
+++ b/storage/history.go
@@ -161,6 +161,10 @@ func (s *LocalStorage) GetHistory(limit int) ([]string, error) {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrReadHistory, err)
+	}
+
 	return items, nil
 }
 

--- a/storage/history.go
+++ b/storage/history.go
@@ -96,7 +96,7 @@ func (s *LocalStorage) GetHistory(limit int) ([]string, error) {
 			return items, nil
 		}
 
-		return nil, ErrReadHistory
+		return nil, fmt.Errorf("%w: %w", ErrReadHistory, err)
 	}
 
 	defer func() {
@@ -107,7 +107,7 @@ func (s *LocalStorage) GetHistory(limit int) ([]string, error) {
 		fStats, err := f.Stat()
 
 		if err != nil {
-			return nil, ErrReadHistory
+			return nil, fmt.Errorf("%w: %w", ErrReadHistory, err)
 		}
 
 		if fStats.Size() == 0 {
@@ -125,7 +125,7 @@ func (s *LocalStorage) GetHistory(limit int) ([]string, error) {
 					return items, nil
 				}
 
-				return nil, ErrReadHistory
+				return nil, fmt.Errorf("%w: %w", ErrReadHistory, err)
 			}
 
 			item, err := parseHistoryItem(string(b))

--- a/storage/history_test.go
+++ b/storage/history_test.go
@@ -1,8 +1,10 @@
 package storage
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +61,19 @@ func Test_GetHistory(t *testing.T) {
 	assert.Equal(t, []string{
 		fmt.Sprintf("2 | %s | command2\n> https://globalping.io?measurement=id2", time2.Format("2006-01-02 15:04:05")),
 	}, items)
+}
+
+func Test_GetHistory_ForwardScannerError(t *testing.T) {
+	_storage := createDefaultTestStorage(t)
+	history := "1|1|1730310880|id1|command1\n" +
+		"1|2|1730310890|id2|" + strings.Repeat("x", bufio.MaxScanTokenSize) + "\n"
+	assert.NoError(t, os.WriteFile(_storage.historyPath(), []byte(history), 0644))
+
+	items, err := _storage.GetHistory(0)
+
+	assert.ErrorIs(t, err, ErrReadHistory)
+	assert.ErrorContains(t, err, "token too long")
+	assert.Empty(t, items)
 }
 
 func Test_SaveCommandToHistory(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -77,10 +77,14 @@ func (s *LocalStorage) Init(dirName string) error {
 			if err != nil {
 				return err
 			}
+		} else {
+			return fmt.Errorf("failed to load config: %w", err)
 		}
 	}
 
-	_ = s.Migrate()
+	if err := s.Migrate(); err != nil {
+		return fmt.Errorf("failed to migrate storage: %w", err)
+	}
 
 	return nil
 }

--- a/view/infinite.go
+++ b/view/infinite.go
@@ -23,6 +23,12 @@ func (v *viewer) OutputInfinite(measurement *globalping.Measurement) (string, er
 		v.ctx.Table = true
 	}
 
+	if v.ctx.ToLatency || v.ctx.Table {
+		if err := validateFinishedPingStats(measurement); err != nil {
+			return "", err
+		}
+	}
+
 	if v.ctx.ToLatency {
 		return v.outputInfinitePingLatency(measurement)
 	}

--- a/view/table.go
+++ b/view/table.go
@@ -48,6 +48,12 @@ func (v *viewer) OutputTable(measurement *globalping.Measurement) (string, error
 		return "", v.outputFailSummary(measurement)
 	}
 
+	if measurement.Type == "ping" {
+		if err := validateFinishedPingStats(measurement); err != nil {
+			return "", err
+		}
+	}
+
 	v.ctx.TableOutputRows = len(measurement.Results)
 	v.outputTableView(measurement)
 
@@ -56,6 +62,22 @@ func (v *viewer) OutputTable(measurement *globalping.Measurement) (string, error
 	}
 
 	return "", nil
+}
+
+func validateFinishedPingStats(measurement *globalping.Measurement) error {
+	for i := range measurement.Results {
+		result := &measurement.Results[i].Result
+
+		if result.Status != globalping.TestStatusFinished {
+			continue
+		}
+
+		if _, err := globalping.DecodePingStats(result.StatsRaw); err != nil {
+			return fmt.Errorf("failed to decode ping statistics for result %d: %w", i+1, err)
+		}
+	}
+
+	return nil
 }
 
 func (v *viewer) outputTableView(m *globalping.Measurement) {


### PR DESCRIPTION
Closes #186 

Most errors were already handled correctly via Cobra, however, the following was updated:

- `api/probe/container_engine.go` — Preserve Docker and Podman detection diagnostics.
- `api/probe/probe.go` — Classify probe state and wrap subprocess failures.
- `cmd/history.go` — Return history failures through Cobra correctly.
- `cmd/install_probe.go` — Return unexpected probe installation failures through Cobra.
- `cmd/limits.go` — Warn on introspection; return limits request failures.
- `storage/history.go` — Preserve causes for every history read failure.
- `storage/storage.go` — Return configuration loading and migration failures.
- `view/infinite.go` — Reject malformed finished statistics in infinite output.
- `view/table.go` — Reject malformed finished statistics in ping tables.